### PR TITLE
Updated build.gradle to include dependencies for android

### DIFF
--- a/MediaPicker/build.gradle
+++ b/MediaPicker/build.gradle
@@ -25,4 +25,11 @@ android {
     lintOptions {
         warningsAsErrors true
     }
+
+    dependencies {
+        implementation 'androidx.core:core-ktx:1.6.0'
+        implementation 'androidx.appcompat:appcompat:1.3.0'
+        implementation 'com.google.android.material:material:1.4.0'
+        implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    }
 }


### PR DESCRIPTION
This PR just adds the missing dependencies to the `mediapicker` module. 