### PR TITLE
Add Buildkite & remote build cache support

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,28 @@
+docker-container: &docker-container
+  plugins:
+    - docker#v3.8.0:
+        image: "public.ecr.aws/m4u4m2y0/android-build-image:latest"
+        environment:
+          - "CI=true"
+
+steps:
+  - label: "ktlint"
+    <<: *docker-container
+    command: |
+      cp gradle.properties-example gradle.properties
+      ./gradlew ciktlint
+  - label: "lint"
+    <<: *docker-container
+    command: |
+      cp gradle.properties-example gradle.properties
+      ./gradlew lintRelease
+  - label: "Unit test"
+    <<: *docker-container
+    command: |
+      cp gradle.properties-example gradle.properties
+      ./gradlew testRelease
+  - label: "Assemble Release"
+    <<: *docker-container
+    command: |
+      cp gradle.properties-example gradle.properties
+      ./gradlew assembleRelease

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,3 +18,15 @@ pluginManagement {
 rootProject.name = "MediaPicker"
 include ':MediaPicker',
         ':sampleapp'
+
+// Build cache is only enabled for CI, at least for now
+if (System.getenv().containsKey("CI")) {
+    buildCache {
+        remote(HttpBuildCache) {
+            url = "http://10.0.2.215:5071/cache/"
+            allowUntrustedServer = true
+            allowInsecureProtocol = true
+            push = true
+        }
+    }
+}


### PR DESCRIPTION
This PR adds Buildkite support following a similar implementation to [WordPress-Android](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/.buildkite/pipeline.yml) and ports the CI setup proposed in https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/pull/13. It also adds remote build caching support to speed up the CI builds.

* I don't think we want run `assembleRelease` separately since artifact publishing will cover that. However, since it's requested, I am fine with adding it now and removing it when we add artifact publishing support.
* I also don't think we want to use these catch all tasks in the root level and instead should call project specific tasks to make it easier to understand what's going on at a glance. However, the current setup will make it easier to play with the project setup, so let's keep it and re-visit when the project is a bit more mature.

**To test:**
* The builds don't currently pass locally or in CI, so I think we just merge this in and address any issues when the project builds properly.