### PR TITLE
Comment out WordPress only related code from `insert` package

### DIFF
--- a/MediaPicker/src/main/java/org/wordpress/android/mediapicker/MediaPickerSetup.kt
+++ b/MediaPicker/src/main/java/org/wordpress/android/mediapicker/MediaPickerSetup.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.mediapicker
 import android.content.Intent
 import android.os.Bundle
 import androidx.annotation.StringRes
-import org.wordpress.android.R
 
 data class MediaPickerSetup(
     val primaryDataSource: DataSource,
@@ -19,7 +18,10 @@ data class MediaPickerSetup(
     @StringRes val title: Int
 ) {
     enum class DataSource {
-        DEVICE, WP_LIBRARY, STOCK_LIBRARY, GIF_LIBRARY
+        DEVICE,
+        WP_LIBRARY,
+//        STOCK_LIBRARY,
+//        GIF_LIBRARY
     }
 
     enum class CameraSetup {

--- a/MediaPicker/src/main/java/org/wordpress/android/mediapicker/insert/GifMediaInsertUseCase.kt
+++ b/MediaPicker/src/main/java/org/wordpress/android/mediapicker/insert/GifMediaInsertUseCase.kt
@@ -1,107 +1,107 @@
-package org.wordpress.android.mediapicker.insert
-
-import android.content.Context
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.yield
-
-import org.wordpress.android.R
-import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.generated.MediaActionBuilder
-import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.modules.IO_THREAD
-import org.wordpress.android.mediapicker.MediaItem.Identifier
-import org.wordpress.android.mediapicker.MediaItem.Identifier.GifMediaIdentifier
-import org.wordpress.android.mediapicker.MediaItem.Identifier.LocalId
-import org.wordpress.android.mediapicker.insert.MediaInsertHandler.InsertModel
-import org.wordpress.android.util.FluxCUtilsWrapper
-import org.wordpress.android.util.MimeTypeMapUtilsWrapper
-import org.wordpress.android.util.WPMediaUtilsWrapper
-import javax.inject.Inject
-import javax.inject.Named
-
-class GifMediaInsertUseCase(
-    private val context: Context,
-    private val site: SiteModel,
-    private val dispatcher: Dispatcher,
-    private val ioDispatcher: CoroutineDispatcher,
-    private val wpMediaUtilsWrapper: WPMediaUtilsWrapper,
-    private val fluxCUtilsWrapper: FluxCUtilsWrapper,
-    private val mimeTypeMapUtilsWrapper: MimeTypeMapUtilsWrapper
-) : MediaInsertUseCase {
-    override val actionTitle: Int
-        get() = R.string.media_uploading_gif_library_photo
-
-    override suspend fun insert(identifiers: List<Identifier>) = flow {
-        emit(InsertModel.Progress(actionTitle))
-        emit(coroutineScope {
-                return@coroutineScope try {
-                    val mediaIdentifiers = identifiers.mapNotNull { identifier ->
-                        (identifier as? GifMediaIdentifier)?.let {
-                            fetchAndSaveAsync(this, it, site)
-                        }
-                    }
-
-                    InsertModel.Success(mediaIdentifiers.awaitAll().filterNotNull())
-                } catch (e: CancellationException) {
-                    InsertModel.Success(listOf<GifMediaIdentifier>())
-                } catch (e: Exception) {
-                    InsertModel.Error(context.getString(R.string.error_downloading_image))
-                }
-            }
-        )
-    }
-
-    private fun fetchAndSaveAsync(
-        scope: CoroutineScope,
-        gifIdentifier: GifMediaIdentifier,
-        site: SiteModel
-    ): Deferred<LocalId?> = scope.async(ioDispatcher) {
-        return@async gifIdentifier.largeImageUri.let { mediaUri ->
-            // No need to log the Exception here. The underlying method that is used, [MediaUtils.downloadExternalMedia]
-            // already logs any errors.
-            val downloadedUri = wpMediaUtilsWrapper.fetchMediaToUriWrapper(mediaUri)
-                    ?: throw Exception("Failed to download the image.")
-
-            // Exit if the parent coroutine has already been cancelled
-            yield()
-
-            val fileExtension = mimeTypeMapUtilsWrapper.getFileExtensionFromUrl(mediaUri.toString())
-            val mimeType = mimeTypeMapUtilsWrapper.getSingleton().getMimeTypeFromExtension(fileExtension)
-
-            val mediaModel = fluxCUtilsWrapper.mediaModelFromLocalUri(downloadedUri.uri, mimeType, site.id)
-            mediaModel?.title = gifIdentifier.title
-            dispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mediaModel))
-
-            mediaModel?.id?.let { LocalId(it) }
-        }
-    }
-
-    class GifMediaInsertUseCaseFactory
-    @Inject constructor(
-        private val context: Context,
-        private val dispatcher: Dispatcher,
-        @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher,
-        private val wpMediaUtilsWrapper: WPMediaUtilsWrapper,
-        private val fluxCUtilsWrapper: FluxCUtilsWrapper,
-        private val mimeTypeMapUtilsWrapper: MimeTypeMapUtilsWrapper
-    ) {
-        fun build(site: SiteModel): GifMediaInsertUseCase {
-            return GifMediaInsertUseCase(
-                    context,
-                    site,
-                    dispatcher,
-                    ioDispatcher,
-                    wpMediaUtilsWrapper,
-                    fluxCUtilsWrapper,
-                    mimeTypeMapUtilsWrapper
-            )
-        }
-    }
-}
+//package org.wordpress.android.mediapicker.insert
+//
+//import android.content.Context
+//import kotlinx.coroutines.CancellationException
+//import kotlinx.coroutines.CoroutineDispatcher
+//import kotlinx.coroutines.CoroutineScope
+//import kotlinx.coroutines.Deferred
+//import kotlinx.coroutines.async
+//import kotlinx.coroutines.awaitAll
+//import kotlinx.coroutines.coroutineScope
+//import kotlinx.coroutines.flow.flow
+//import kotlinx.coroutines.yield
+//
+//import org.wordpress.android.R
+//import org.wordpress.android.fluxc.Dispatcher
+//import org.wordpress.android.fluxc.generated.MediaActionBuilder
+//import org.wordpress.android.fluxc.model.SiteModel
+//import org.wordpress.android.modules.IO_THREAD
+//import org.wordpress.android.mediapicker.MediaItem.Identifier
+//import org.wordpress.android.mediapicker.MediaItem.Identifier.GifMediaIdentifier
+//import org.wordpress.android.mediapicker.MediaItem.Identifier.LocalId
+//import org.wordpress.android.mediapicker.insert.MediaInsertHandler.InsertModel
+//import org.wordpress.android.util.FluxCUtilsWrapper
+//import org.wordpress.android.util.MimeTypeMapUtilsWrapper
+//import org.wordpress.android.util.WPMediaUtilsWrapper
+//import javax.inject.Inject
+//import javax.inject.Named
+//
+//class GifMediaInsertUseCase(
+//    private val context: Context,
+//    private val site: SiteModel,
+//    private val dispatcher: Dispatcher,
+//    private val ioDispatcher: CoroutineDispatcher,
+//    private val wpMediaUtilsWrapper: WPMediaUtilsWrapper,
+//    private val fluxCUtilsWrapper: FluxCUtilsWrapper,
+//    private val mimeTypeMapUtilsWrapper: MimeTypeMapUtilsWrapper
+//) : MediaInsertUseCase {
+//    override val actionTitle: Int
+//        get() = R.string.media_uploading_gif_library_photo
+//
+//    override suspend fun insert(identifiers: List<Identifier>) = flow {
+//        emit(InsertModel.Progress(actionTitle))
+//        emit(coroutineScope {
+//                return@coroutineScope try {
+//                    val mediaIdentifiers = identifiers.mapNotNull { identifier ->
+//                        (identifier as? GifMediaIdentifier)?.let {
+//                            fetchAndSaveAsync(this, it, site)
+//                        }
+//                    }
+//
+//                    InsertModel.Success(mediaIdentifiers.awaitAll().filterNotNull())
+//                } catch (e: CancellationException) {
+//                    InsertModel.Success(listOf<GifMediaIdentifier>())
+//                } catch (e: Exception) {
+//                    InsertModel.Error(context.getString(R.string.error_downloading_image))
+//                }
+//            }
+//        )
+//    }
+//
+//    private fun fetchAndSaveAsync(
+//        scope: CoroutineScope,
+//        gifIdentifier: GifMediaIdentifier,
+//        site: SiteModel
+//    ): Deferred<LocalId?> = scope.async(ioDispatcher) {
+//        return@async gifIdentifier.largeImageUri.let { mediaUri ->
+//            // No need to log the Exception here. The underlying method that is used, [MediaUtils.downloadExternalMedia]
+//            // already logs any errors.
+//            val downloadedUri = wpMediaUtilsWrapper.fetchMediaToUriWrapper(mediaUri)
+//                    ?: throw Exception("Failed to download the image.")
+//
+//            // Exit if the parent coroutine has already been cancelled
+//            yield()
+//
+//            val fileExtension = mimeTypeMapUtilsWrapper.getFileExtensionFromUrl(mediaUri.toString())
+//            val mimeType = mimeTypeMapUtilsWrapper.getSingleton().getMimeTypeFromExtension(fileExtension)
+//
+//            val mediaModel = fluxCUtilsWrapper.mediaModelFromLocalUri(downloadedUri.uri, mimeType, site.id)
+//            mediaModel?.title = gifIdentifier.title
+//            dispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mediaModel))
+//
+//            mediaModel?.id?.let { LocalId(it) }
+//        }
+//    }
+//
+//    class GifMediaInsertUseCaseFactory
+//    @Inject constructor(
+//        private val context: Context,
+//        private val dispatcher: Dispatcher,
+//        @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher,
+//        private val wpMediaUtilsWrapper: WPMediaUtilsWrapper,
+//        private val fluxCUtilsWrapper: FluxCUtilsWrapper,
+//        private val mimeTypeMapUtilsWrapper: MimeTypeMapUtilsWrapper
+//    ) {
+//        fun build(site: SiteModel): GifMediaInsertUseCase {
+//            return GifMediaInsertUseCase(
+//                    context,
+//                    site,
+//                    dispatcher,
+//                    ioDispatcher,
+//                    wpMediaUtilsWrapper,
+//                    fluxCUtilsWrapper,
+//                    mimeTypeMapUtilsWrapper
+//            )
+//        }
+//    }
+//}

--- a/MediaPicker/src/main/java/org/wordpress/android/mediapicker/insert/MediaInsertHandlerFactory.kt
+++ b/MediaPicker/src/main/java/org/wordpress/android/mediapicker/insert/MediaInsertHandlerFactory.kt
@@ -1,32 +1,31 @@
 package org.wordpress.android.mediapicker.insert
 
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.mediapicker.MediaPickerSetup
 import org.wordpress.android.mediapicker.insert.DeviceListInsertUseCase.DeviceListInsertUseCaseFactory
 import org.wordpress.android.mediapicker.MediaPickerSetup.DataSource.DEVICE
-import org.wordpress.android.mediapicker.MediaPickerSetup.DataSource.GIF_LIBRARY
-import org.wordpress.android.mediapicker.MediaPickerSetup.DataSource.STOCK_LIBRARY
+//import org.wordpress.android.mediapicker.MediaPickerSetup.DataSource.GIF_LIBRARY
+//import org.wordpress.android.mediapicker.MediaPickerSetup.DataSource.STOCK_LIBRARY
 import org.wordpress.android.mediapicker.MediaPickerSetup.DataSource.WP_LIBRARY
-import org.wordpress.android.mediapicker.insert.GifMediaInsertUseCase.GifMediaInsertUseCaseFactory
-import org.wordpress.android.mediapicker.insert.StockMediaInsertUseCase.StockMediaInsertUseCaseFactory
+//import org.wordpress.android.mediapicker.insert.GifMediaInsertUseCase.GifMediaInsertUseCaseFactory
+//import org.wordpress.android.mediapicker.insert.StockMediaInsertUseCase.StockMediaInsertUseCaseFactory
 import javax.inject.Inject
 
 class MediaInsertHandlerFactory
 @Inject constructor(
     private val deviceListInsertUseCaseFactory: DeviceListInsertUseCaseFactory,
-    private val stockMediaInsertUseCaseFactory: StockMediaInsertUseCaseFactory,
-    private val gifMediaInsertUseCaseFactory: GifMediaInsertUseCaseFactory
+//    private val stockMediaInsertUseCaseFactory: StockMediaInsertUseCaseFactory,
+//    private val gifMediaInsertUseCaseFactory: GifMediaInsertUseCaseFactory
 ) {
-    fun build(mediaPickerSetup: MediaPickerSetup, siteModel: SiteModel?): MediaInsertHandler {
+    fun build(mediaPickerSetup: MediaPickerSetup): MediaInsertHandler {
         return when (mediaPickerSetup.primaryDataSource) {
             DEVICE -> deviceListInsertUseCaseFactory.build(mediaPickerSetup.queueResults)
             WP_LIBRARY -> DefaultMediaInsertUseCase
-            STOCK_LIBRARY -> stockMediaInsertUseCaseFactory.build(requireNotNull(siteModel) {
-                "Site is necessary when inserting into stock media library "
-            })
-            GIF_LIBRARY -> gifMediaInsertUseCaseFactory.build(requireNotNull(siteModel) {
-                "Site is necessary when inserting into gif media library "
-            })
+//            STOCK_LIBRARY -> stockMediaInsertUseCaseFactory.build(requireNotNull(siteModel) {
+//                "Site is necessary when inserting into stock media library "
+//            })
+//            GIF_LIBRARY -> gifMediaInsertUseCaseFactory.build(requireNotNull(siteModel) {
+//                "Site is necessary when inserting into gif media library "
+//            })
         }.toMediaInsertHandler()
     }
 

--- a/MediaPicker/src/main/java/org/wordpress/android/mediapicker/insert/MediaInsertUseCase.kt
+++ b/MediaPicker/src/main/java/org/wordpress/android/mediapicker/insert/MediaInsertUseCase.kt
@@ -2,8 +2,8 @@ package org.wordpress.android.mediapicker.insert
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import org.wordpress.android.R
 import org.wordpress.android.mediapicker.MediaItem.Identifier
+import org.wordpress.android.mediapicker.R
 import org.wordpress.android.mediapicker.insert.MediaInsertHandler.InsertModel
 import org.wordpress.android.mediapicker.insert.MediaInsertHandler.InsertModel.Success
 

--- a/MediaPicker/src/main/java/org/wordpress/android/mediapicker/insert/StockMediaInsertUseCase.kt
+++ b/MediaPicker/src/main/java/org/wordpress/android/mediapicker/insert/StockMediaInsertUseCase.kt
@@ -1,62 +1,62 @@
-package org.wordpress.android.mediapicker.insert
-
-import kotlinx.coroutines.flow.flow
-import org.wordpress.android.R
-import org.wordpress.android.analytics.AnalyticsTracker
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.STOCK_MEDIA_UPLOADED
-import org.wordpress.android.fluxc.model.MediaModel
-import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.StockMediaStore
-import org.wordpress.android.fluxc.store.StockMediaUploadItem
-import org.wordpress.android.mediapicker.MediaItem.Identifier
-import org.wordpress.android.mediapicker.MediaItem.Identifier.StockMediaIdentifier
-import org.wordpress.android.mediapicker.insert.MediaInsertHandler.InsertModel
-import org.wordpress.android.util.AppLog
-import org.wordpress.android.util.AppLog.T.MEDIA
-import java.util.HashMap
-import javax.inject.Inject
-
-class StockMediaInsertUseCase(
-    private val site: SiteModel,
-    private val stockMediaStore: StockMediaStore
-) : MediaInsertUseCase {
-    override val actionTitle: Int
-        get() = R.string.media_uploading_stock_library_photo
-
-    override suspend fun insert(identifiers: List<Identifier>) = flow {
-        emit(InsertModel.Progress(actionTitle))
-        val result = stockMediaStore.performUploadStockMedia(site, identifiers.mapNotNull { identifier ->
-            (identifier as? StockMediaIdentifier)?.let {
-                StockMediaUploadItem(it.name, it.title, it.url)
-            }
-        })
-        emit(when {
-            result.error != null -> InsertModel.Error(result.error.message)
-            else -> {
-                trackUploadedStockMediaEvent(result.mediaList)
-                InsertModel.Success(result.mediaList.mapNotNull { Identifier.RemoteId(it.mediaId) })
-            }
-        })
-    }
-
-    private fun trackUploadedStockMediaEvent(mediaList: List<MediaModel>) {
-        if (mediaList.isEmpty()) {
-            AppLog.e(MEDIA, "Cannot track uploaded stock media event if mediaList is empty")
-            return
-        }
-        val isMultiselect = mediaList.size > 1
-        val properties: MutableMap<String, Any?> = HashMap()
-        properties["is_part_of_multiselection"] = isMultiselect
-        properties["number_of_media_selected"] = mediaList.size
-        AnalyticsTracker.track(STOCK_MEDIA_UPLOADED, properties)
-    }
-
-    class StockMediaInsertUseCaseFactory
-    @Inject constructor(
-        private val stockMediaStore: StockMediaStore
-    ) {
-        fun build(site: SiteModel): StockMediaInsertUseCase {
-            return StockMediaInsertUseCase(site, stockMediaStore)
-        }
-    }
-}
+//package org.wordpress.android.mediapicker.insert
+//
+//import kotlinx.coroutines.flow.flow
+//import org.wordpress.android.R
+//import org.wordpress.android.analytics.AnalyticsTracker
+//import org.wordpress.android.analytics.AnalyticsTracker.Stat.STOCK_MEDIA_UPLOADED
+//import org.wordpress.android.fluxc.model.MediaModel
+//import org.wordpress.android.fluxc.model.SiteModel
+//import org.wordpress.android.fluxc.store.StockMediaStore
+//import org.wordpress.android.fluxc.store.StockMediaUploadItem
+//import org.wordpress.android.mediapicker.MediaItem.Identifier
+//import org.wordpress.android.mediapicker.MediaItem.Identifier.StockMediaIdentifier
+//import org.wordpress.android.mediapicker.insert.MediaInsertHandler.InsertModel
+//import org.wordpress.android.util.AppLog
+//import org.wordpress.android.util.AppLog.T.MEDIA
+//import java.util.HashMap
+//import javax.inject.Inject
+//
+//class StockMediaInsertUseCase(
+//    private val site: SiteModel,
+//    private val stockMediaStore: StockMediaStore
+//) : MediaInsertUseCase {
+//    override val actionTitle: Int
+//        get() = R.string.media_uploading_stock_library_photo
+//
+//    override suspend fun insert(identifiers: List<Identifier>) = flow {
+//        emit(InsertModel.Progress(actionTitle))
+//        val result = stockMediaStore.performUploadStockMedia(site, identifiers.mapNotNull { identifier ->
+//            (identifier as? StockMediaIdentifier)?.let {
+//                StockMediaUploadItem(it.name, it.title, it.url)
+//            }
+//        })
+//        emit(when {
+//            result.error != null -> InsertModel.Error(result.error.message)
+//            else -> {
+//                trackUploadedStockMediaEvent(result.mediaList)
+//                InsertModel.Success(result.mediaList.mapNotNull { Identifier.RemoteId(it.mediaId) })
+//            }
+//        })
+//    }
+//
+//    private fun trackUploadedStockMediaEvent(mediaList: List<MediaModel>) {
+//        if (mediaList.isEmpty()) {
+//            AppLog.e(MEDIA, "Cannot track uploaded stock media event if mediaList is empty")
+//            return
+//        }
+//        val isMultiselect = mediaList.size > 1
+//        val properties: MutableMap<String, Any?> = HashMap()
+//        properties["is_part_of_multiselection"] = isMultiselect
+//        properties["number_of_media_selected"] = mediaList.size
+//        AnalyticsTracker.track(STOCK_MEDIA_UPLOADED, properties)
+//    }
+//
+//    class StockMediaInsertUseCaseFactory
+//    @Inject constructor(
+//        private val stockMediaStore: StockMediaStore
+//    ) {
+//        fun build(site: SiteModel): StockMediaInsertUseCase {
+//            return StockMediaInsertUseCase(site, stockMediaStore)
+//        }
+//    }
+//}

--- a/MediaPicker/src/main/res/values/strings.xml
+++ b/MediaPicker/src/main/res/values/strings.xml
@@ -2,4 +2,8 @@
 <resources>
     <string name="sdcard_title">SD Card Required</string>
     <string name="sdcard_message">A mounted SD card is required to upload media</string>
+
+    <string name="photo_picker_photo_or_video_title">Choose media</string>
+    <string name="media_uploading_default">Uploading media</string>
+
 </resources>


### PR DESCRIPTION
The purpose of this PR is to make `insert` package not "compile-able" aka not red-highlighted:

![image](https://user-images.githubusercontent.com/5845095/126481330-5149157b-088e-49e2-bdae-29288047a892.png)

I'm commenting here code related to `GIF` and `Stock` media sources categories as they are strictly connected to WordPress only use cases and supporting WordPress is a second milestone.

Those are also much more complicated use cases as they relay on 3rd party image providers.

I've decided to not remove those classes and comment only as this way we'll maintain original git history if we revert those files later.

Closes #19 