### PR TITLE
Cleaned up MediaThumbnailViewUtils

### DIFF
--- a/MediaPicker/build.gradle
+++ b/MediaPicker/build.gradle
@@ -41,5 +41,8 @@ android {
         // Remove dependency to Utils
         implementation 'com.android.volley:volley:1.2.0'
         implementation 'org.wordpress:utils:2.0.0'
+
+        // Glide
+        implementation 'com.github.bumptech.glide:glide:4.12.0'
     }
 }

--- a/MediaPicker/src/main/java/org/wordpress/android/mediapicker/MediaThumbnailViewUtils.kt
+++ b/MediaPicker/src/main/java/org/wordpress/android/mediapicker/MediaThumbnailViewUtils.kt
@@ -3,21 +3,13 @@ package org.wordpress.android.mediapicker
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
-import org.wordpress.android.R
+import com.bumptech.glide.Glide
 import org.wordpress.android.mediapicker.MediaPickerUiItem.ClickAction
 import org.wordpress.android.mediapicker.MediaPickerUiItem.ToggleAction
-import org.wordpress.android.util.AccessibilityUtils
-import org.wordpress.android.util.AniUtils
-import org.wordpress.android.util.AniUtils.Duration.SHORT
-import org.wordpress.android.util.ColorUtils.setImageResourceWithTint
-import org.wordpress.android.util.PhotoPickerUtils
-import org.wordpress.android.util.ViewUtils
-import org.wordpress.android.util.WPMediaUtils
-import org.wordpress.android.util.image.ImageManager
-import org.wordpress.android.util.redirectContextClickToLongPressListener
+import org.wordpress.android.util.*
 import java.util.Locale
 
-class MediaThumbnailViewUtils(val imageManager: ImageManager) {
+class MediaThumbnailViewUtils {
     fun setupListeners(
         imgThumbnail: ImageView,
         isSelected: Boolean,
@@ -28,10 +20,7 @@ class MediaThumbnailViewUtils(val imageManager: ImageManager) {
         addImageSelectedToAccessibilityFocusedEvent(imgThumbnail, isSelected)
         imgThumbnail.setOnClickListener {
             toggleAction.toggle()
-            PhotoPickerUtils.announceSelectedImageForAccessibility(
-                    imgThumbnail,
-                    isSelected
-            )
+            imgThumbnail.announceSelectedImageForAccessibility(isSelected)
         }
         imgThumbnail.setOnLongClickListener {
             clickAction.click()
@@ -50,22 +39,16 @@ class MediaThumbnailViewUtils(val imageManager: ImageManager) {
         toggleAction: ToggleAction,
         animateSelection: Boolean
     ) {
-        imageManager.cancelRequestAndClearImageView(imgThumbnail)
+        Glide.with(imgThumbnail.context).clear(imgThumbnail)
 
         // not an image or video, so show file name and file type
         val placeholderResId = WPMediaUtils.getPlaceholder(fileName)
-        setImageResourceWithTint(
-                imgThumbnail, placeholderResId,
-                R.color.neutral_30
-        )
+        imgThumbnail.setImageResourceWithTint(placeholderResId, R.color.neutral_30)
 
         addImageSelectedToAccessibilityFocusedEvent(imgThumbnail, isSelected)
         container.setOnClickListener {
             toggleAction.toggle()
-            PhotoPickerUtils.announceSelectedImageForAccessibility(
-                    imgThumbnail,
-                    isSelected
-            )
+            imgThumbnail.announceSelectedImageForAccessibility(isSelected)
         }
         container.setOnLongClickListener {
             clickAction.click()
@@ -100,20 +83,11 @@ class MediaThumbnailViewUtils(val imageManager: ImageManager) {
 
     private fun displaySelection(animate: Boolean, isSelected: Boolean, view: View) {
         if (animate) {
+            val duration = view.context.resources.getInteger(ANI_DURATION).toLong()
             if (isSelected) {
-                AniUtils.scale(
-                        view,
-                        SCALE_NORMAL,
-                        SCALE_SELECTED,
-                        ANI_DURATION
-                )
+                view.scale(SCALE_NORMAL, SCALE_SELECTED, duration)
             } else {
-                AniUtils.scale(
-                        view,
-                        SCALE_SELECTED,
-                        SCALE_NORMAL,
-                        ANI_DURATION
-                )
+                view.scale(SCALE_SELECTED, SCALE_NORMAL, duration)
             }
         } else {
             val scale = if (isSelected) SCALE_SELECTED else SCALE_NORMAL
@@ -131,25 +105,11 @@ class MediaThumbnailViewUtils(val imageManager: ImageManager) {
         txtSelectionCount: TextView
     ) {
         if (animate) {
+            val duration = txtSelectionCount.context.resources.getInteger(ANI_DURATION).toLong()
             when {
-                showOrderCounter -> {
-                    AniUtils.startAnimation(
-                            txtSelectionCount,
-                            R.anim.pop
-                    )
-                }
-                isSelected -> {
-                    AniUtils.fadeIn(
-                            txtSelectionCount,
-                            ANI_DURATION
-                    )
-                }
-                else -> {
-                    AniUtils.fadeOut(
-                            txtSelectionCount,
-                            ANI_DURATION
-                    )
-                }
+                showOrderCounter -> txtSelectionCount.startAnimation(R.anim.pop)
+                isSelected -> txtSelectionCount.fadeIn(duration)
+                else -> txtSelectionCount.fadeOut(duration)
             }
         } else {
             txtSelectionCount.visibility = if (showOrderCounter || isSelected) View.VISIBLE else View.GONE
@@ -198,6 +158,6 @@ class MediaThumbnailViewUtils(val imageManager: ImageManager) {
     companion object {
         private const val SCALE_NORMAL = 1.0f
         private const val SCALE_SELECTED = .8f
-        private val ANI_DURATION = SHORT
+        private val ANI_DURATION = R.integer.config_shortAnimTime
     }
 }

--- a/MediaPicker/src/main/java/org/wordpress/android/util/ViewUtils.kt
+++ b/MediaPicker/src/main/java/org/wordpress/android/util/ViewUtils.kt
@@ -1,0 +1,95 @@
+package org.wordpress.android.util
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.ObjectAnimator
+import android.animation.PropertyValuesHolder
+import android.os.Build
+import android.view.View
+import android.view.animation.AccelerateDecelerateInterpolator
+import android.view.animation.AnimationUtils
+import android.view.animation.LinearInterpolator
+import android.widget.ImageView
+import androidx.annotation.ColorRes
+import androidx.annotation.DrawableRes
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.content.ContextCompat
+import androidx.core.widget.ImageViewCompat
+import org.wordpress.android.mediapicker.R
+
+fun View.redirectContextClickToLongPressListener() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        this.setOnContextClickListener { it.performLongClick() }
+    }
+}
+
+fun View?.scale(scaleStart: Float, scaleEnd: Float, duration: Long) {
+    if (this == null) {
+        return
+    }
+    val scaleX = PropertyValuesHolder.ofFloat(View.SCALE_X, scaleStart, scaleEnd)
+    val scaleY = PropertyValuesHolder.ofFloat(View.SCALE_Y, scaleStart, scaleEnd)
+    val animator = ObjectAnimator.ofPropertyValuesHolder(this, scaleX, scaleY)
+    animator.duration = duration
+    animator.interpolator = AccelerateDecelerateInterpolator()
+    animator.start()
+}
+
+fun View?.startAnimation(aniResId: Int) {
+    if (this == null) {
+        return
+    }
+    val animation = AnimationUtils.loadAnimation(context, aniResId)
+    startAnimation(animation)
+}
+
+fun View?.fadeIn(duration: Long) {
+    this?.let { view ->
+        ObjectAnimator.ofFloat(this, View.ALPHA, 0.0f, 1.0f).apply {
+            this.duration = duration
+            this.interpolator = LinearInterpolator()
+            this.addListener(object : AnimatorListenerAdapter() {
+                override fun onAnimationStart(animation: Animator) {
+                    view.visibility = View.VISIBLE
+                }
+            })
+        }.start()
+    }
+}
+
+fun View?.fadeOut(duration: Long) {
+    this?.let { view ->
+        ObjectAnimator.ofFloat(this, View.ALPHA, 1.0f, 0.0f).apply {
+            this.duration = duration
+            this.interpolator = LinearInterpolator()
+            this.addListener(object : AnimatorListenerAdapter() {
+                override fun onAnimationStart(animation: Animator) {
+                    view.visibility = View.GONE
+                }
+            })
+        }.start()
+    }
+}
+
+fun ImageView.setImageResourceWithTint(
+    @DrawableRes drawableResId: Int,
+    @ColorRes colorResId: Int
+) {
+    setImageDrawable(ContextCompat.getDrawable(context, drawableResId))
+    ImageViewCompat.setImageTintList(
+        this,
+        AppCompatResources.getColorStateList(context, colorResId)
+    )
+}
+
+fun ImageView.announceSelectedImageForAccessibility(itemSelected: Boolean) {
+    if (itemSelected) {
+        announceForAccessibility(
+            context.getString(R.string.photo_picker_image_thumbnail_selected)
+        )
+    } else {
+        announceForAccessibility(
+            context.getString(R.string.photo_picker_image_thumbnail_unselected)
+        )
+    }
+}

--- a/MediaPicker/src/main/res/anim/pop.xml
+++ b/MediaPicker/src/main/res/anim/pop.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<scale xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@android:integer/config_longAnimTime"
+    android:fillAfter="true"
+    android:fromXScale="0.0"
+    android:fromYScale="0.0"
+    android:interpolator="@android:anim/overshoot_interpolator"
+    android:pivotX="50%"
+    android:pivotY="50%"
+    android:toXScale="1.0"
+    android:toYScale="1.0" />

--- a/MediaPicker/src/main/res/drawable/media_picker_circle_pressed.xml
+++ b/MediaPicker/src/main/res/drawable/media_picker_circle_pressed.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:shape="oval">
+    <solid android:color="?attr/colorSecondary"/>
+</shape>

--- a/MediaPicker/src/main/res/values/colors.xml
+++ b/MediaPicker/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="neutral_30">#8c8f94</color>
+</resources>

--- a/MediaPicker/src/main/res/values/integers.xml
+++ b/MediaPicker/src/main/res/values/integers.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- The duration (in milliseconds) of a short animation. -->
+    <integer name="config_shortAnimTime">200</integer>
+</resources>

--- a/MediaPicker/src/main/res/values/strings.xml
+++ b/MediaPicker/src/main/res/values/strings.xml
@@ -2,4 +2,7 @@
 <resources>
     <string name="sdcard_title">SD Card Required</string>
     <string name="sdcard_message">A mounted SD card is required to upload media</string>
+    <string name="photo_picker_image_selected">,Selected</string>
+    <string name="photo_picker_image_thumbnail_selected">Image selected</string>
+    <string name="photo_picker_image_thumbnail_unselected">Image unselected</string>
 </resources>


### PR DESCRIPTION
As part of #34 , this PR takes care of cleaning up `MediaThumbnailViewUtils`.

### Changes
- Added some color, drawable, string resources to the module.
- Removed reference to `ImageManager`. Instead I just called the same Glide module to load/clear the images. There are a lot of instances of `ImageManager` though so not sure if this might be needed during other clean ups.
- Added a `ViewUtils` class instead of using the `AniUtils` and `PhotoPickerUtils` class from WordPress.