### PR TITLE
Use constant for take photo intent

### DIFF
--- a/MediaPicker/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/MediaPicker/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.wordpress.android.mediapicker.MediaPickerConstants.ARG_EDIT_IMAGE_DATA;
+import static org.wordpress.android.mediapicker.MediaPickerRequestCodes.TAKE_PHOTO;
 
 public class WPMediaUtils {
 
@@ -68,8 +69,7 @@ public class WPMediaUtils {
     public static void launchCamera(Activity activity, String applicationId, LaunchCameraCallback callback) {
         Intent intent = prepareLaunchCamera(activity, applicationId, callback);
         if (intent != null) {
-            // wzieba TODO: 20/07/2021 Sync request code with library consumer
-            activity.startActivityForResult(intent, 2100);
+            activity.startActivityForResult(intent, TAKE_PHOTO);
         }
     }
 


### PR DESCRIPTION
As mentioned here: https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/pull/33#discussion_r673709008 , `TAKE_PHOTO` constant is now used instead of raw int.

This made me thought about improving it some day in the future: #45 