### PR TITLE
Update Dagger to 2.42

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     gradle.ext.kotlinVersion = '1.6.10'
-    gradle.ext.daggerVersion = '2.40.5'
+    gradle.ext.daggerVersion = '2.42'
     gradle.ext.agpVersion = '7.2.1'
 
     plugins {


### PR DESCRIPTION
AGP `7.2.1` update results in a crash during lint due to a bug in Dagger which is addressed in `2.42`. This PR updates Dagger to `2.42` and targets the AGP update branch, so they can be shipped together.