### PR TITLE
Fix race condition that resulted in duplicate images when uploading multiple files

### DIFF
--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/MediaPickerUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/MediaPickerUtils.kt
@@ -132,8 +132,8 @@ class MediaPickerUtils @Inject constructor(
                                     path = cachedFile.absolutePath
                                 }
                             }
+                        }
                     }
-                }
             } catch (e: IOException) {
                 log.e(e)
             }

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/MediaPickerUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/MediaPickerUtils.kt
@@ -172,14 +172,12 @@ class MediaPickerUtils @Inject constructor(
     }
 
     private fun createTempFile(): File? {
-        var file: File? = null
-        try {
-            val tempFileName = "temp-${System.currentTimeMillis()}.jpg"
-            file = File(context.cacheDir, tempFileName)
+        return try {
+            File.createTempFile("temp-${System.currentTimeMillis()}", ".jpg")
         } catch (e: RuntimeException) {
             log.e(e)
+            null
         }
-        return file
     }
 
     private fun readBinaryStream(

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/MediaPickerUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/MediaPickerUtils.kt
@@ -113,7 +113,7 @@ class MediaPickerUtils @Inject constructor(
         }
     }
 
-    fun getMediaStoreFilePath(uri: Uri): String? {
+    private fun getMediaStoreFilePath(uri: Uri): String? {
         var path: String? = null
         if (VERSION.SDK_INT >= VERSION_CODES.Q) {
             try {

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/MediaPickerUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/MediaPickerUtils.kt
@@ -118,18 +118,20 @@ class MediaPickerUtils @Inject constructor(
         if (VERSION.SDK_INT >= VERSION_CODES.Q) {
             try {
                 val cachedFile = createTempFile()
-                val parcelFileDescriptor = context.contentResolver.openFile(uri, "r", null)
-                parcelFileDescriptor?.fileDescriptor?.let { fd ->
-                    val input = FileInputStream(fd)
-                    val byteArray = readBinaryStream(
-                        input,
-                        parcelFileDescriptor.statSize.toInt()
-                    )
-                    if (cachedFile != null) {
-                        val fileSaved = writeFile(cachedFile, byteArray)
-                        if (fileSaved) {
-                            path = cachedFile.absolutePath
-                        }
+                context.contentResolver.openFile(uri, "r", null)
+                    .use { parcelFileDescriptor ->
+                        parcelFileDescriptor?.fileDescriptor?.let { fd ->
+                            val input = FileInputStream(fd)
+                            val byteArray = readBinaryStream(
+                                input,
+                                parcelFileDescriptor.statSize.toInt()
+                            )
+                            if (cachedFile != null) {
+                                val fileSaved = writeFile(cachedFile, byteArray)
+                                if (fileSaved) {
+                                    path = cachedFile.absolutePath
+                                }
+                            }
                     }
                 }
             } catch (e: IOException) {


### PR DESCRIPTION
In Android 11 and later, as we can't get the image's path from the MediaStore, we copy the file to the caches directory; this code was buggy as it resulted in overriding files when dealing with multiple files, as we were using a "timestamped" file name and writing to it without checking if it exists.
The change of this PR solves this by switching to `File.createTempFile` as it handles this safely by assigning a random number to the file name.

Check https://github.com/woocommerce/woocommerce-android/pull/7459 for more details.