### PR TITLE
Update `minSdkVersion` (from `21` to `24`)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ subprojects {
 ext {
     minSdkVersion = 21
     compileSdkVersion = 31
-    targetSdkVersion = 30
+    targetSdkVersion = 31
     buildToolsVersion = "30.0.3"
 
     daggerVersion = gradle.ext.daggerVersion

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ subprojects {
 }
 
 ext {
-    minSdkVersion = 21
+    minSdkVersion = 24
     compileSdkVersion = 31
     targetSdkVersion = 31
     buildToolsVersion = "30.0.3"

--- a/mediapicker/source-device/src/main/java/org/wordpress/android/mediapicker/source/device/DeviceMediaLoader.kt
+++ b/mediapicker/source-device/src/main/java/org/wordpress/android/mediapicker/source/device/DeviceMediaLoader.kt
@@ -3,8 +3,7 @@ package org.wordpress.android.mediapicker.source.device
 import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
-import android.os.Build.VERSION
-import android.os.Build.VERSION_CODES
+import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.provider.MediaStore.Audio
@@ -33,7 +32,7 @@ class DeviceMediaLoader @Inject constructor(
         pageSize: Int,
         limitDate: Long? = null
     ): DeviceMediaList {
-        val baseUri = if (VERSION.SDK_INT >= VERSION_CODES.Q /*29*/) {
+        val baseUri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q /*29*/) {
             when (mediaType) {
                 IMAGE -> Images.Media.getContentUri(VOLUME_EXTERNAL)
                 VIDEO -> Video.Media.getContentUri(VOLUME_EXTERNAL)
@@ -123,7 +122,7 @@ class DeviceMediaLoader @Inject constructor(
         pageSize: Int,
         baseUri: Uri,
         projection: Array<String>
-    ) = if (VERSION.SDK_INT >= VERSION_CODES.Q /*29*/) {
+    ) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q /*29*/) {
         val bundle = Bundle().apply {
             putString(ContentResolver.QUERY_ARG_SQL_SELECTION, condition)
             putStringArray(

--- a/mediapicker/source-device/src/main/java/org/wordpress/android/mediapicker/source/device/DeviceMediaPickerSetup.kt
+++ b/mediapicker/source-device/src/main/java/org/wordpress/android/mediapicker/source/device/DeviceMediaPickerSetup.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.mediapicker.source.device
 
 import android.os.Build
-import android.os.Build.VERSION_CODES
 import org.wordpress.android.mediapicker.api.MediaPickerSetup
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.CAMERA
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.DEVICE
@@ -45,7 +44,7 @@ class DeviceMediaPickerSetup {
                 primaryDataSource = CAMERA,
                 availableDataSources = emptySet(),
                 isMultiSelectEnabled = false,
-                isStoragePermissionRequired = Build.VERSION.SDK_INT < VERSION_CODES.Q,
+                isStoragePermissionRequired = Build.VERSION.SDK_INT < Build.VERSION_CODES.Q,
                 allowedTypes = setOf(IMAGE),
                 areResultsQueued = false,
                 searchMode = HIDDEN

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/MediaManager.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/MediaManager.kt
@@ -4,7 +4,6 @@ import android.content.ContentValues
 import android.content.Context
 import android.net.Uri
 import android.os.Build
-import android.os.Build.VERSION_CODES
 import android.os.Environment
 import android.provider.MediaStore
 import android.provider.MediaStore.Images.Media
@@ -28,7 +27,7 @@ internal class MediaManager @Inject constructor(
     }
 
     suspend fun addImageToMediaStore(path: String): Uri? {
-        return if (Build.VERSION.SDK_INT >= VERSION_CODES.Q) {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             saveImageInQ(path)
         } else {
             saveImageLegacy(path)
@@ -44,7 +43,7 @@ internal class MediaManager @Inject constructor(
         }
     }
 
-    @RequiresApi(VERSION_CODES.Q)
+    @RequiresApi(Build.VERSION_CODES.Q)
     private suspend fun saveImageInQ(path: String): Uri? {
         val uri: Uri?
         withContext(Dispatchers.IO) {

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/MediaPickerUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/MediaPickerUtils.kt
@@ -5,8 +5,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.media.MediaScannerConnection
 import android.net.Uri
-import android.os.Build.VERSION
-import android.os.Build.VERSION_CODES
+import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
 import android.provider.MediaStore.Images.Media
@@ -35,7 +34,7 @@ class MediaPickerUtils @Inject constructor(
 ) {
     val externalStorageDir: File?
         get() {
-            return if (VERSION.SDK_INT >= VERSION_CODES.Q) {
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 context.getExternalFilesDir(Environment.DIRECTORY_DCIM)
             } else {
                 @Suppress("Deprecation")
@@ -115,7 +114,7 @@ class MediaPickerUtils @Inject constructor(
 
     private fun getMediaStoreFilePath(uri: Uri): String? {
         var path: String? = null
-        if (VERSION.SDK_INT >= VERSION_CODES.Q) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             try {
                 val cachedFile = createTempFile()
                 context.contentResolver.openFile(uri, "r", null)

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaPickerPermissionUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaPickerPermissionUtils.kt
@@ -8,7 +8,6 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
-import android.os.Build.VERSION_CODES
 import android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -148,7 +147,7 @@ internal class MediaPickerPermissionUtils @Inject constructor(
         return when (permission) {
             Manifest.permission.READ_EXTERNAL_STORAGE,
             Manifest.permission.WRITE_EXTERNAL_STORAGE -> context.getString(
-                if (Build.VERSION.SDK_INT > VERSION_CODES.Q)
+                if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q)
                     string.permission_files_and_media
                 else
                     string.permission_storage

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/ViewUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/ViewUtils.kt
@@ -4,16 +4,13 @@ import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.animation.ObjectAnimator
 import android.animation.PropertyValuesHolder
-import android.os.Build
 import android.view.View
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.view.animation.AnimationUtils
 import android.view.animation.LinearInterpolator
 
 fun View.redirectContextClickToLongPressListener() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        this.setOnContextClickListener { it.performLongClick() }
-    }
+    this.setOnContextClickListener { it.performLongClick() }
 }
 
 fun View?.scale(scaleStart: Float, scaleEnd: Float, duration: Long) {

--- a/sampleapp/src/main/AndroidManifest.xml
+++ b/sampleapp/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     package="org.wordpress.android.sampleapp">
 
     <application
-        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"


### PR DESCRIPTION
This PR upgrades Media Picker to `minSdkVersion` to `24`. This has been unblocked because `WCAndroid` has been recently upgraded to `minSdkVersion = 24` as well (see [here](https://github.com/woocommerce/woocommerce-android/pull/7643)).

-----

As part of this `minSdkVersion = 24` upgrade the below changes were also applied in order to fix any additional warnings that this change brought-up:

Target SDK Version:

1. [Update target sdk version to 31.](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/c6104d5e74d1bc0034108cfd6bcce143bee84f42)
2. [Resolve sata extraction rules warning for sample app module.](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/10ace9408f9e618678556d698ea3a16b040a676c)

Warnings Resolution List:

1. [Resolve obsolete sdk int lint warning for view utils.](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/1a70783bde1802bc22ece86c725e26306abab855)

Refactor List:

1. [Optimize android os build imports.](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/879f0f08b604c0c8da37248c24eb88c687e6252d)

-----

### Testing instructions

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could:
    - Quickly smoke test the `SampleApp` app and see if it works as expected.
    - Try and install the `SampleApp` on Android 5 (`API 21/22`) and Android 6 (`API 23`) devices and verify that you can't (see [API Levels](https://apilevels.com/)).