### PR TITLE
Use Android AMI in Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,35 +1,26 @@
-common-params:
-  &publish-android-artifacts-docker-container
-  docker#v3.8.0:
-    image: "public.ecr.aws/automattic/android-build-image:v1.2.0"
-    propagate-environment: true
-    environment:
-      # DO NOT MANUALLY SET THESE VALUES!
-      # They are passed from the Buildkite agent to the Docker container
-      - "AWS_ACCESS_KEY"
-      - "AWS_SECRET_KEY"
+common_params:
+  # Common plugin settings to use with the `plugins` key.
+  - &common_plugins
+    - automattic/bash-cache#2.11.0
 
 steps:
   - label: "ktlint"
     key: "ktlint"
-    plugins:
-      - *publish-android-artifacts-docker-container
+    plugins: *common_plugins
     command: |
       ./gradlew ciktlint
     artifact_paths:
       - "**/build/ktlint.xml"
   - label: "lint"
     key: "lint"
-    plugins:
-      - *publish-android-artifacts-docker-container
+    plugins: *common_plugins
     command: |
       ./gradlew lintRelease
     artifact_paths:
       - "**/build/reports/lint-results*.*"
   - label: "Unit test"
     key: "unit-test"
-    plugins:
-      - *publish-android-artifacts-docker-container
+    plugins: *common_plugins
     command: |
       ./gradlew testRelease
 
@@ -40,35 +31,30 @@ steps:
       - "ktlint"
       - "lint"
       - "unit-test"
-    plugins:
-      - *publish-android-artifacts-docker-container
+    plugins: *common_plugins
     command: |
       .buildkite/publish-mediapicker-domain.sh
   - label: "Publish :mediapicker:source-device"
     depends_on:
       - "publish-mediapicker-domain"
-    plugins:
-      - *publish-android-artifacts-docker-container
+    plugins: *common_plugins
     command: |
       .buildkite/publish-mediapicker-source-device.sh
   - label: "Publish :mediapicker:source-gif"
     depends_on:
       - "publish-mediapicker-domain"
-    plugins:
-      - *publish-android-artifacts-docker-container
+    plugins: *common_plugins
     command: |
       .buildkite/publish-mediapicker-source-gif.sh
   - label: "Publish :mediapicker:source-wordpress"
     depends_on:
       - "publish-mediapicker-domain"
-    plugins:
-      - *publish-android-artifacts-docker-container
+    plugins: *common_plugins
     command: |
       .buildkite/publish-mediapicker-source-wordpress.sh
   - label: "Publish :mediapicker"
     depends_on:
       - "publish-mediapicker-domain"
-    plugins:
-      - *publish-android-artifacts-docker-container
+    plugins: *common_plugins
     command: |
       .buildkite/publish-mediapicker.sh


### PR DESCRIPTION
This PR switches Buildkite builds from Docker to Android AMI. This is a change we have made in most of our repositories, but this is one of the repositories that was left behind.

**To test**

If the CI is green, we are good to :shipit: 