### PR TITLE
[Compile Warnings As Errors] Resolve Warnings & Enable All Warnings as Errors

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,11 +26,6 @@ steps:
       ./gradlew lintRelease
     artifact_paths:
       - "**/build/reports/lint-results*.*"
-  - label: "Unit test"
-    key: "unit-test"
-    plugins: *common_plugins
-    command: |
-      ./gradlew testRelease
 
   # Publish tasks
   - label: "Publish :mediapicker:domain"
@@ -38,7 +33,6 @@ steps:
     depends_on:
       - "detekt"
       - "lint"
-      - "unit-test"
     plugins: *common_plugins
     command: |
       .buildkite/publish-mediapicker-domain.sh

--- a/build.gradle
+++ b/build.gradle
@@ -63,8 +63,8 @@ ext {
     glideVersion = '4.12.0'
     googleMaterialVersion = '1.5.0'
     kotlinxCoroutinesVersion = '1.5.2'
+    squareupRetrofitVersion = "2.9.0"
     wordpressUtilsVersion = "2.4.0"
-    retrofitVersion = "2.9.0"
     fluxCVersion = 'develop-fa819801570505a0e9b4f7f226bb704b88ccc1d2'
     mediaPickerDomainDependency = project.hasProperty("mediaPickerDomainVersion") ? "org.wordpress.mediapicker:domain:${project.getProperty("mediaPickerDomainVersion")}" : project(":mediapicker:domain")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -58,10 +58,10 @@ ext {
     androidxConstraintlayoutVersion = '2.1.1'
     androidxLifecycleVersion = '2.4.0'
     androidxSwipeToRefreshVersion = '1.1.0'
+    chrisbanesPhotoviewVersion = '2.3.0'
     glideVersion = '4.12.0'
     googleMaterialVersion = '1.5.0'
     kotlinxCoroutinesVersion = '1.5.2'
-    photoViewVersion = '2.3.0'
     navigationFragmentVersion = '2.3.5'
     wordpressUtilsVersion = "2.4.0"
     retrofitVersion = "2.9.0"

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ ext {
     androidxLifecycleVersion = '2.4.0'
     androidxSwipeToRefreshVersion = '1.1.0'
     glideVersion = '4.12.0'
-    coroutinesVersion = '1.5.2'
+    kotlinxCoroutinesVersion = '1.5.2'
     materialVersion = '1.5.0'
     photoViewVersion = '2.3.0'
     navigationFragmentVersion = '2.3.5'

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ ext {
 }
 
 ext {
+    wordPressFluxCVersion = 'develop-fa819801570505a0e9b4f7f226bb704b88ccc1d2'
     wordpressUtilsVersion = "2.4.0"
 
     androidxAppcompatVersion = '1.4.1'
@@ -66,7 +67,6 @@ ext {
     googleMaterialVersion = '1.5.0'
     kotlinxCoroutinesVersion = '1.5.2'
     squareupRetrofitVersion = "2.9.0"
-    fluxCVersion = 'develop-fa819801570505a0e9b4f7f226bb704b88ccc1d2'
     mediaPickerDomainDependency = project.hasProperty("mediaPickerDomainVersion") ? "org.wordpress.mediapicker:domain:${project.getProperty("mediaPickerDomainVersion")}" : project(":mediapicker:domain")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,11 @@ ext {
 }
 
 ext {
+    // libs
     wordPressFluxCVersion = 'develop-fa819801570505a0e9b4f7f226bb704b88ccc1d2'
     wordpressUtilsVersion = "2.4.0"
 
+    // main
     androidxAppcompatVersion = '1.4.1'
     androidxCoreVersion = '1.7.0'
     androidxDatastoreVersion = '1.0.0'
@@ -67,6 +69,8 @@ ext {
     googleMaterialVersion = '1.5.0'
     kotlinxCoroutinesVersion = '1.5.2'
     squareupRetrofitVersion = "2.9.0"
+
+    // project
     mediaPickerDomainDependency = project.hasProperty("mediaPickerDomainVersion") ? "org.wordpress.mediapicker:domain:${project.getProperty("mediaPickerDomainVersion")}" : project(":mediapicker:domain")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,6 @@ ext {
 }
 
 ext {
-    daggerVersion = gradle.ext.daggerVersion
     glideVersion = '4.12.0'
     hiltVersion = '1.0.0'
     lifecycleVersion = '2.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id 'io.gitlab.arturbosch.detekt' apply false
     id 'com.android.application' apply false
@@ -26,6 +28,12 @@ allprojects {
         ignoreFailures = false
         parallel = true
         debug = false
+    }
+
+    tasks.withType(KotlinCompile).all {
+        kotlinOptions {
+            allWarningsAsErrors = true
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,8 @@ ext {
 }
 
 ext {
+    wordpressUtilsVersion = "2.4.0"
+
     androidxAppcompatVersion = '1.4.1'
     androidxCoreVersion = '1.7.0'
     androidxDatastoreVersion = '1.0.0'
@@ -64,7 +66,6 @@ ext {
     googleMaterialVersion = '1.5.0'
     kotlinxCoroutinesVersion = '1.5.2'
     squareupRetrofitVersion = "2.9.0"
-    wordpressUtilsVersion = "2.4.0"
     fluxCVersion = 'develop-fa819801570505a0e9b4f7f226bb704b88ccc1d2'
     mediaPickerDomainDependency = project.hasProperty("mediaPickerDomainVersion") ? "org.wordpress.mediapicker:domain:${project.getProperty("mediaPickerDomainVersion")}" : project(":mediapicker:domain")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -54,8 +54,8 @@ ext {
 ext {
     androidxDatastoreVersion = '1.0.0'
     androidxLifecycleVersion = '2.4.0'
+    androidxSwipeToRefreshVersion = '1.1.0'
     glideVersion = '4.12.0'
-    swiperefreshlayoutVersion = '1.1.0'
     constraintlayoutVersion = '2.1.1'
     appcompatVersion = '1.4.1'
     coreVersion = '1.7.0'

--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,8 @@ ext {
     androidxLifecycleVersion = '2.4.0'
     androidxSwipeToRefreshVersion = '1.1.0'
     glideVersion = '4.12.0'
+    googleMaterialVersion = '1.5.0'
     kotlinxCoroutinesVersion = '1.5.2'
-    materialVersion = '1.5.0'
     photoViewVersion = '2.3.0'
     navigationFragmentVersion = '2.3.5'
     wordpressUtilsVersion = "2.4.0"

--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,6 @@ ext {
 }
 
 ext {
-    buildToolsVersion = "30.0.3"
-
     daggerVersion = gradle.ext.daggerVersion
     glideVersion = '4.12.0'
     hiltVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,9 @@ ext {
 }
 
 ext {
+    androidxDatastoreVersion = '1.0.0'
     androidxLifecycleVersion = '2.4.0'
     glideVersion = '4.12.0'
-    datastoreVersion = '1.0.0'
     swiperefreshlayoutVersion = '1.1.0'
     constraintlayoutVersion = '2.1.1'
     appcompatVersion = '1.4.1'

--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ ext {
 }
 
 ext {
+    androidxLifecycleVersion = '2.4.0'
     glideVersion = '4.12.0'
-    lifecycleVersion = '2.4.0'
     datastoreVersion = '1.0.0'
     swiperefreshlayoutVersion = '1.1.0'
     constraintlayoutVersion = '2.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -53,12 +53,12 @@ ext {
 
 ext {
     androidxAppcompatVersion = '1.4.1'
+    androidxCoreVersion = '1.7.0'
     androidxDatastoreVersion = '1.0.0'
     androidxConstraintlayoutVersion = '2.1.1'
     androidxLifecycleVersion = '2.4.0'
     androidxSwipeToRefreshVersion = '1.1.0'
     glideVersion = '4.12.0'
-    coreVersion = '1.7.0'
     coroutinesVersion = '1.5.2'
     materialVersion = '1.5.0'
     photoViewVersion = '2.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -52,12 +52,12 @@ ext {
 }
 
 ext {
+    androidxAppcompatVersion = '1.4.1'
     androidxDatastoreVersion = '1.0.0'
     androidxConstraintlayoutVersion = '2.1.1'
     androidxLifecycleVersion = '2.4.0'
     androidxSwipeToRefreshVersion = '1.1.0'
     glideVersion = '4.12.0'
-    appcompatVersion = '1.4.1'
     coreVersion = '1.7.0'
     coroutinesVersion = '1.5.2'
     materialVersion = '1.5.0'

--- a/build.gradle
+++ b/build.gradle
@@ -53,10 +53,10 @@ ext {
 
 ext {
     androidxDatastoreVersion = '1.0.0'
+    androidxConstraintlayoutVersion = '2.1.1'
     androidxLifecycleVersion = '2.4.0'
     androidxSwipeToRefreshVersion = '1.1.0'
     glideVersion = '4.12.0'
-    constraintlayoutVersion = '2.1.1'
     appcompatVersion = '1.4.1'
     coreVersion = '1.7.0'
     coroutinesVersion = '1.5.2'

--- a/build.gradle
+++ b/build.gradle
@@ -53,10 +53,8 @@ ext {
 
 ext {
     glideVersion = '4.12.0'
-    hiltVersion = '1.0.0'
     lifecycleVersion = '2.4.0'
     datastoreVersion = '1.0.0'
-    hiltVersion = '1.0.0'
     swiperefreshlayoutVersion = '1.1.0'
     constraintlayoutVersion = '2.1.1'
     appcompatVersion = '1.4.1'

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ ext {
     minSdkVersion = 24
     compileSdkVersion = 33
     targetSdkVersion = 33
+}
+
+ext {
     buildToolsVersion = "30.0.3"
 
     daggerVersion = gradle.ext.daggerVersion

--- a/build.gradle
+++ b/build.gradle
@@ -57,12 +57,12 @@ ext {
     androidxDatastoreVersion = '1.0.0'
     androidxConstraintlayoutVersion = '2.1.1'
     androidxLifecycleVersion = '2.4.0'
+    androidxNavigationVersion = '2.3.5'
     androidxSwipeToRefreshVersion = '1.1.0'
     chrisbanesPhotoviewVersion = '2.3.0'
     glideVersion = '4.12.0'
     googleMaterialVersion = '1.5.0'
     kotlinxCoroutinesVersion = '1.5.2'
-    navigationFragmentVersion = '2.3.5'
     wordpressUtilsVersion = "2.4.0"
     retrofitVersion = "2.9.0"
     fluxCVersion = 'develop-fa819801570505a0e9b4f7f226bb704b88ccc1d2'

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,5 @@ org.gradle.jvmargs=-Xmx1536m
 
 android.useAndroidX=true
 android.enableJetifier=false
+
+android.nonTransitiveRClass=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,8 @@
+# Project-wide Gradle settings.
+
+org.gradle.jvmargs=-Xmx1536m
+
+# WordPress-MediaPicker-Android properties.
+
 android.useAndroidX=true
 android.enableJetifier=false
-org.gradle.jvmargs=-Xmx1536m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project-wide Gradle settings.
 
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx6g
 
 # WordPress-MediaPicker-Android properties.
 

--- a/mediapicker/build.gradle
+++ b/mediapicker/build.gradle
@@ -46,7 +46,7 @@ android {
         implementation "androidx.core:core-ktx:$coreVersion"
         implementation "androidx.appcompat:appcompat:$appcompatVersion"
         implementation "androidx.constraintlayout:constraintlayout:$constraintlayoutVersion"
-        implementation "androidx.swiperefreshlayout:swiperefreshlayout:$swiperefreshlayoutVersion"
+        implementation "androidx.swiperefreshlayout:swiperefreshlayout:$androidxSwipeToRefreshVersion"
         implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidxLifecycleVersion"
         implementation "androidx.datastore:datastore-preferences:$androidxDatastoreVersion"
 

--- a/mediapicker/build.gradle
+++ b/mediapicker/build.gradle
@@ -40,7 +40,7 @@ android {
 
         implementation "com.google.android.material:material:$materialVersion"
 
-        implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
+        implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinxCoroutinesVersion"
 
         implementation "androidx.navigation:navigation-fragment-ktx:$navigationFragmentVersion"
         implementation "androidx.core:core-ktx:$androidxCoreVersion"

--- a/mediapicker/build.gradle
+++ b/mediapicker/build.gradle
@@ -10,7 +10,6 @@ plugins {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion rootProject.buildToolsVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/mediapicker/build.gradle
+++ b/mediapicker/build.gradle
@@ -48,7 +48,7 @@ android {
         implementation "androidx.constraintlayout:constraintlayout:$constraintlayoutVersion"
         implementation "androidx.swiperefreshlayout:swiperefreshlayout:$swiperefreshlayoutVersion"
         implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidxLifecycleVersion"
-        implementation "androidx.datastore:datastore-preferences:$datastoreVersion"
+        implementation "androidx.datastore:datastore-preferences:$androidxDatastoreVersion"
 
         implementation "com.github.bumptech.glide:glide:$glideVersion"
 

--- a/mediapicker/build.gradle
+++ b/mediapicker/build.gradle
@@ -43,7 +43,7 @@ android {
         implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
 
         implementation "androidx.navigation:navigation-fragment-ktx:$navigationFragmentVersion"
-        implementation "androidx.core:core-ktx:$coreVersion"
+        implementation "androidx.core:core-ktx:$androidxCoreVersion"
         implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
         implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintlayoutVersion"
         implementation "androidx.swiperefreshlayout:swiperefreshlayout:$androidxSwipeToRefreshVersion"

--- a/mediapicker/build.gradle
+++ b/mediapicker/build.gradle
@@ -42,7 +42,7 @@ android {
 
         implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinxCoroutinesVersion"
 
-        implementation "androidx.navigation:navigation-fragment-ktx:$navigationFragmentVersion"
+        implementation "androidx.navigation:navigation-fragment-ktx:$androidxNavigationVersion"
         implementation "androidx.core:core-ktx:$androidxCoreVersion"
         implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
         implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintlayoutVersion"

--- a/mediapicker/build.gradle
+++ b/mediapicker/build.gradle
@@ -47,7 +47,7 @@ android {
         implementation "androidx.appcompat:appcompat:$appcompatVersion"
         implementation "androidx.constraintlayout:constraintlayout:$constraintlayoutVersion"
         implementation "androidx.swiperefreshlayout:swiperefreshlayout:$swiperefreshlayoutVersion"
-        implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
+        implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidxLifecycleVersion"
         implementation "androidx.datastore:datastore-preferences:$datastoreVersion"
 
         implementation "com.github.bumptech.glide:glide:$glideVersion"

--- a/mediapicker/build.gradle
+++ b/mediapicker/build.gradle
@@ -56,7 +56,7 @@ android {
         implementation "com.google.dagger:hilt-android-compiler:$gradle.ext.daggerVersion"
         kapt "com.google.dagger:hilt-compiler:$gradle.ext.daggerVersion"
 
-        implementation "com.github.chrisbanes:PhotoView:$photoViewVersion"
+        implementation "com.github.chrisbanes:PhotoView:$chrisbanesPhotoviewVersion"
 
         implementation "org.wordpress:utils:$wordpressUtilsVersion"
     }

--- a/mediapicker/build.gradle
+++ b/mediapicker/build.gradle
@@ -52,9 +52,9 @@ android {
 
         implementation "com.github.bumptech.glide:glide:$glideVersion"
 
-        implementation "com.google.dagger:hilt-android:$daggerVersion"
-        implementation "com.google.dagger:hilt-android-compiler:$daggerVersion"
-        kapt "com.google.dagger:hilt-compiler:$daggerVersion"
+        implementation "com.google.dagger:hilt-android:$gradle.ext.daggerVersion"
+        implementation "com.google.dagger:hilt-android-compiler:$gradle.ext.daggerVersion"
+        kapt "com.google.dagger:hilt-compiler:$gradle.ext.daggerVersion"
 
         implementation "com.github.chrisbanes:PhotoView:$photoViewVersion"
 

--- a/mediapicker/build.gradle
+++ b/mediapicker/build.gradle
@@ -38,7 +38,7 @@ android {
     dependencies {
         api mediaPickerDomainDependency
 
-        implementation "com.google.android.material:material:$materialVersion"
+        implementation "com.google.android.material:material:$googleMaterialVersion"
 
         implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinxCoroutinesVersion"
 

--- a/mediapicker/build.gradle
+++ b/mediapicker/build.gradle
@@ -45,7 +45,7 @@ android {
         implementation "androidx.navigation:navigation-fragment-ktx:$navigationFragmentVersion"
         implementation "androidx.core:core-ktx:$coreVersion"
         implementation "androidx.appcompat:appcompat:$appcompatVersion"
-        implementation "androidx.constraintlayout:constraintlayout:$constraintlayoutVersion"
+        implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintlayoutVersion"
         implementation "androidx.swiperefreshlayout:swiperefreshlayout:$androidxSwipeToRefreshVersion"
         implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidxLifecycleVersion"
         implementation "androidx.datastore:datastore-preferences:$androidxDatastoreVersion"

--- a/mediapicker/build.gradle
+++ b/mediapicker/build.gradle
@@ -44,7 +44,7 @@ android {
 
         implementation "androidx.navigation:navigation-fragment-ktx:$navigationFragmentVersion"
         implementation "androidx.core:core-ktx:$coreVersion"
-        implementation "androidx.appcompat:appcompat:$appcompatVersion"
+        implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
         implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintlayoutVersion"
         implementation "androidx.swiperefreshlayout:swiperefreshlayout:$androidxSwipeToRefreshVersion"
         implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidxLifecycleVersion"

--- a/mediapicker/domain/build.gradle
+++ b/mediapicker/domain/build.gradle
@@ -21,7 +21,7 @@ android {
 }
 
 dependencies {
-    implementation "androidx.core:core-ktx:$coreVersion"
+    implementation "androidx.core:core-ktx:$androidxCoreVersion"
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
 }

--- a/mediapicker/domain/build.gradle
+++ b/mediapicker/domain/build.gradle
@@ -9,7 +9,6 @@ plugins {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion rootProject.buildToolsVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/mediapicker/domain/build.gradle
+++ b/mediapicker/domain/build.gradle
@@ -23,7 +23,7 @@ android {
 dependencies {
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
 
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinxCoroutinesVersion"
 }
 
 project.afterEvaluate {

--- a/mediapicker/source-device/build.gradle
+++ b/mediapicker/source-device/build.gradle
@@ -10,7 +10,6 @@ plugins {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion rootProject.buildToolsVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/mediapicker/source-device/build.gradle
+++ b/mediapicker/source-device/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     implementation mediaPickerDomainDependency
 
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinxCoroutinesVersion"
 
     implementation "com.google.dagger:hilt-android:$gradle.ext.daggerVersion"
     implementation "com.google.dagger:hilt-android-compiler:$gradle.ext.daggerVersion"

--- a/mediapicker/source-device/build.gradle
+++ b/mediapicker/source-device/build.gradle
@@ -26,9 +26,9 @@ dependencies {
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
 
-    implementation "com.google.dagger:hilt-android:$daggerVersion"
-    implementation "com.google.dagger:hilt-android-compiler:$daggerVersion"
-    kapt "com.google.dagger:hilt-compiler:$daggerVersion"
+    implementation "com.google.dagger:hilt-android:$gradle.ext.daggerVersion"
+    implementation "com.google.dagger:hilt-android-compiler:$gradle.ext.daggerVersion"
+    kapt "com.google.dagger:hilt-compiler:$gradle.ext.daggerVersion"
 }
 
 project.afterEvaluate {

--- a/mediapicker/source-gif/build.gradle
+++ b/mediapicker/source-gif/build.gradle
@@ -10,7 +10,6 @@ plugins {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion rootProject.buildToolsVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/mediapicker/source-gif/build.gradle
+++ b/mediapicker/source-gif/build.gradle
@@ -28,9 +28,9 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
 
-    implementation "com.google.dagger:hilt-android:$daggerVersion"
-    implementation "com.google.dagger:hilt-android-compiler:$daggerVersion"
-    kapt "com.google.dagger:hilt-compiler:$daggerVersion"
+    implementation "com.google.dagger:hilt-android:$gradle.ext.daggerVersion"
+    implementation "com.google.dagger:hilt-android-compiler:$gradle.ext.daggerVersion"
+    kapt "com.google.dagger:hilt-compiler:$gradle.ext.daggerVersion"
 
     implementation "org.wordpress:utils:$wordpressUtilsVersion"
 }

--- a/mediapicker/source-gif/build.gradle
+++ b/mediapicker/source-gif/build.gradle
@@ -25,8 +25,8 @@ dependencies {
     implementation mediaPickerDomainDependency
 
     implementation (name:'tenor-android-core-jetified', ext:'aar') // Jetified Tenor Gif library
-    implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
-    implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
+    implementation "com.squareup.retrofit2:retrofit:$squareupRetrofitVersion"
+    implementation "com.squareup.retrofit2:converter-gson:$squareupRetrofitVersion"
 
     implementation "com.google.dagger:hilt-android:$gradle.ext.daggerVersion"
     implementation "com.google.dagger:hilt-android-compiler:$gradle.ext.daggerVersion"

--- a/mediapicker/source-gif/src/main/java/org/wordpress/android/mediapicker/source/gif/GifMediaDataSource.kt
+++ b/mediapicker/source-gif/src/main/java/org/wordpress/android/mediapicker/source/gif/GifMediaDataSource.kt
@@ -36,8 +36,8 @@ class GifMediaDataSource
 
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             return Failure(
-                UiStringRes(R.string.no_network_title),
-                htmlSubtitle = UiStringRes(R.string.no_network_message),
+                UiStringRes(org.wordpress.android.mediapicker.api.R.string.no_network_title),
+                htmlSubtitle = UiStringRes(org.wordpress.android.mediapicker.api.R.string.no_network_message),
                 image = org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_load_error_image,
                 data = items
             )
@@ -70,7 +70,7 @@ class GifMediaDataSource
                             Failure(
                                 UiStringRes(R.string.media_loading_failed),
                                 htmlSubtitle = UiStringText(errorMessage),
-                                image = R.drawable.media_picker_lib_load_error_image,
+                                image = org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_load_error_image,
                                 data = items
                             )
                         )
@@ -87,7 +87,7 @@ class GifMediaDataSource
         return Empty(
             title,
             null,
-            R.drawable.media_picker_lib_empty_gallery_image,
+            org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_empty_gallery_image,
             R.drawable.img_tenor_100dp,
             UiStringRes(R.string.gif_powered_by_tenor)
         )

--- a/mediapicker/source-gif/src/main/java/org/wordpress/android/mediapicker/source/gif/GifMediaDataSource.kt
+++ b/mediapicker/source-gif/src/main/java/org/wordpress/android/mediapicker/source/gif/GifMediaDataSource.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.mediapicker.source.gif.util.NetworkUtilsWrapper
 import javax.inject.Inject
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
+import org.wordpress.android.mediapicker.api.R as MPApiR
 
 class GifMediaDataSource
 @Inject constructor(
@@ -36,9 +37,9 @@ class GifMediaDataSource
 
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             return Failure(
-                UiStringRes(org.wordpress.android.mediapicker.api.R.string.no_network_title),
-                htmlSubtitle = UiStringRes(org.wordpress.android.mediapicker.api.R.string.no_network_message),
-                image = org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_load_error_image,
+                UiStringRes(MPApiR.string.no_network_title),
+                htmlSubtitle = UiStringRes(MPApiR.string.no_network_message),
+                image = MPApiR.drawable.media_picker_lib_load_error_image,
                 data = items
             )
         }
@@ -70,7 +71,7 @@ class GifMediaDataSource
                             Failure(
                                 UiStringRes(R.string.media_loading_failed),
                                 htmlSubtitle = UiStringText(errorMessage),
-                                image = org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_load_error_image,
+                                image = MPApiR.drawable.media_picker_lib_load_error_image,
                                 data = items
                             )
                         )
@@ -87,7 +88,7 @@ class GifMediaDataSource
         return Empty(
             title,
             null,
-            org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_empty_gallery_image,
+            MPApiR.drawable.media_picker_lib_empty_gallery_image,
             R.drawable.img_tenor_100dp,
             UiStringRes(R.string.gif_powered_by_tenor)
         )

--- a/mediapicker/source-gif/src/main/java/org/wordpress/android/mediapicker/source/gif/GifMediaDataSource.kt
+++ b/mediapicker/source-gif/src/main/java/org/wordpress/android/mediapicker/source/gif/GifMediaDataSource.kt
@@ -7,7 +7,6 @@ import org.wordpress.android.mediapicker.api.MediaSource.MediaLoadingResult
 import org.wordpress.android.mediapicker.api.MediaSource.MediaLoadingResult.Empty
 import org.wordpress.android.mediapicker.api.MediaSource.MediaLoadingResult.Failure
 import org.wordpress.android.mediapicker.api.MediaSource.MediaLoadingResult.Success
-import org.wordpress.android.mediapicker.api.R.drawable
 import org.wordpress.android.mediapicker.model.MediaItem
 import org.wordpress.android.mediapicker.model.MediaItem.Identifier.GifMedia
 import org.wordpress.android.mediapicker.model.MediaType.IMAGE
@@ -39,7 +38,7 @@ class GifMediaDataSource
             return Failure(
                 UiStringRes(R.string.no_network_title),
                 htmlSubtitle = UiStringRes(R.string.no_network_message),
-                image = drawable.media_picker_lib_load_error_image,
+                image = org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_load_error_image,
                 data = items
             )
         }

--- a/mediapicker/source-wordpress/build.gradle
+++ b/mediapicker/source-wordpress/build.gradle
@@ -10,7 +10,6 @@ plugins {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion rootProject.buildToolsVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/mediapicker/source-wordpress/build.gradle
+++ b/mediapicker/source-wordpress/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 
     implementation "org.wordpress:utils:$wordpressUtilsVersion"
 
-    implementation("org.wordpress:fluxc:$fluxCVersion") {
+    implementation("org.wordpress:fluxc:$wordPressFluxCVersion") {
         exclude group: "com.android.support"
         exclude group: "org.wordpress", module: "utils"
     }

--- a/mediapicker/source-wordpress/build.gradle
+++ b/mediapicker/source-wordpress/build.gradle
@@ -26,9 +26,9 @@ dependencies {
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
 
-    implementation "com.google.dagger:hilt-android:$daggerVersion"
-    implementation "com.google.dagger:hilt-android-compiler:$daggerVersion"
-    kapt "com.google.dagger:hilt-compiler:$daggerVersion"
+    implementation "com.google.dagger:hilt-android:$gradle.ext.daggerVersion"
+    implementation "com.google.dagger:hilt-android-compiler:$gradle.ext.daggerVersion"
+    kapt "com.google.dagger:hilt-compiler:$gradle.ext.daggerVersion"
 
     implementation "org.wordpress:utils:$wordpressUtilsVersion"
 

--- a/mediapicker/source-wordpress/build.gradle
+++ b/mediapicker/source-wordpress/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     implementation mediaPickerDomainDependency
 
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinxCoroutinesVersion"
 
     implementation "com.google.dagger:hilt-android:$gradle.ext.daggerVersion"
     implementation "com.google.dagger:hilt-android-compiler:$gradle.ext.daggerVersion"

--- a/mediapicker/source-wordpress/src/main/java/org/wordpress/android/mediapicker/source/wordpress/MediaLibrarySource.kt
+++ b/mediapicker/source-wordpress/src/main/java/org/wordpress/android/mediapicker/source/wordpress/MediaLibrarySource.kt
@@ -55,9 +55,9 @@ class MediaLibrarySource(
     ): MediaLoadingResult {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             return Failure(
-                UiStringRes(R.string.no_network_title),
+                UiStringRes(org.wordpress.android.mediapicker.api.R.string.no_network_title),
                 htmlSubtitle = UiStringRes(R.string.no_network_message),
-                image = R.drawable.img_illustration_cloud_off_152dp,
+                image = org.wordpress.android.mediapicker.api.R.drawable.img_illustration_cloud_off_152dp,
                 data = if (loadMore) get(mediaTypes, filter) else listOf()
             )
         }
@@ -86,7 +86,7 @@ class MediaLibrarySource(
                 Failure(
                     UiStringRes(R.string.media_loading_failed),
                     htmlSubtitle = UiStringText(error),
-                    image = R.drawable.img_illustration_cloud_off_152dp,
+                    image = org.wordpress.android.mediapicker.api.R.drawable.img_illustration_cloud_off_152dp,
                     data = if (loadMore) get(mediaTypes, filter) else listOf()
                 )
             } else {
@@ -95,8 +95,8 @@ class MediaLibrarySource(
                     MediaLoadingResult.Success(data, hasMore)
                 } else {
                     Empty(
-                        UiStringRes(R.string.media_empty_search_list),
-                        image = R.drawable.img_illustration_empty_results_216dp
+                        UiStringRes(org.wordpress.android.mediapicker.api.R.string.media_empty_search_list),
+                        image = org.wordpress.android.mediapicker.api.R.drawable.img_illustration_empty_results_216dp
                     )
                 }
             }

--- a/mediapicker/source-wordpress/src/main/java/org/wordpress/android/mediapicker/source/wordpress/MediaLibrarySource.kt
+++ b/mediapicker/source-wordpress/src/main/java/org/wordpress/android/mediapicker/source/wordpress/MediaLibrarySource.kt
@@ -33,6 +33,7 @@ import javax.inject.Inject
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
+import org.wordpress.android.mediapicker.api.R as MPApiR
 
 class MediaLibrarySource(
     private val mediaStore: MediaStore,
@@ -55,9 +56,9 @@ class MediaLibrarySource(
     ): MediaLoadingResult {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             return Failure(
-                UiStringRes(org.wordpress.android.mediapicker.api.R.string.no_network_title),
+                UiStringRes(MPApiR.string.no_network_title),
                 htmlSubtitle = UiStringRes(R.string.no_network_message),
-                image = org.wordpress.android.mediapicker.api.R.drawable.img_illustration_cloud_off_152dp,
+                image = MPApiR.drawable.img_illustration_cloud_off_152dp,
                 data = if (loadMore) get(mediaTypes, filter) else listOf()
             )
         }
@@ -86,7 +87,7 @@ class MediaLibrarySource(
                 Failure(
                     UiStringRes(R.string.media_loading_failed),
                     htmlSubtitle = UiStringText(error),
-                    image = org.wordpress.android.mediapicker.api.R.drawable.img_illustration_cloud_off_152dp,
+                    image = MPApiR.drawable.img_illustration_cloud_off_152dp,
                     data = if (loadMore) get(mediaTypes, filter) else listOf()
                 )
             } else {
@@ -95,8 +96,8 @@ class MediaLibrarySource(
                     MediaLoadingResult.Success(data, hasMore)
                 } else {
                     Empty(
-                        UiStringRes(org.wordpress.android.mediapicker.api.R.string.media_empty_search_list),
-                        image = org.wordpress.android.mediapicker.api.R.drawable.img_illustration_empty_results_216dp
+                        UiStringRes(MPApiR.string.media_empty_search_list),
+                        image = MPApiR.drawable.img_illustration_empty_results_216dp
                     )
                 }
             }

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/MediaPickerActionModeCallback.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/MediaPickerActionModeCallback.kt
@@ -9,9 +9,7 @@ import androidx.lifecycle.Lifecycle.Event.ON_START
 import androidx.lifecycle.Lifecycle.Event.ON_STOP
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
-import androidx.lifecycle.Observer
 import org.wordpress.android.mediapicker.R
-import org.wordpress.android.mediapicker.R.id
 import org.wordpress.android.mediapicker.model.UiStateModels.ActionModeUiModel
 import org.wordpress.android.mediapicker.model.UiString.UiStringRes
 import org.wordpress.android.mediapicker.model.UiString.UiStringText
@@ -29,7 +27,7 @@ internal class MediaPickerActionModeCallback(private val viewModel: MediaPickerV
         lifecycleRegistry.handleLifecycleEvent(ON_START)
         val inflater = actionMode.menuInflater
         inflater.inflate(R.menu.media_picker_lib_action_mode, menu)
-        val doneItem = menu.findItem(id.mnu_confirm_selection)
+        val doneItem = menu.findItem(R.id.mnu_confirm_selection)
 
         actionMode.setTitle(viewModel.title)
         viewModel.uiState.observe(this) { uiState ->
@@ -62,7 +60,7 @@ internal class MediaPickerActionModeCallback(private val viewModel: MediaPickerV
         item: MenuItem
     ): Boolean {
         return when (item.itemId) {
-            id.mnu_confirm_selection -> {
+            R.id.mnu_confirm_selection -> {
                 viewModel.onSelectionConfirmed()
                 true
             }

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/MediaPickerActivity.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/MediaPickerActivity.kt
@@ -7,7 +7,7 @@ import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.mediapicker.R.drawable
+import org.wordpress.android.mediapicker.R
 import org.wordpress.android.mediapicker.api.Log
 import org.wordpress.android.mediapicker.api.MediaPickerSetup
 import org.wordpress.android.mediapicker.databinding.MediaPickerLibActivityBinding
@@ -21,7 +21,7 @@ class MediaPickerActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         val binding = MediaPickerLibActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        binding.toolbarMain.setNavigationIcon(drawable.ic_close_white_24dp)
+        binding.toolbarMain.setNavigationIcon(R.drawable.ic_close_white_24dp)
         setSupportActionBar(binding.toolbarMain)
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/MediaPickerFragment.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/MediaPickerFragment.kt
@@ -182,6 +182,7 @@ internal class MediaPickerFragment : Fragment() {
         if (savedInstanceState != null) {
             lastTappedAction = MediaPickerActionEvent.fromBundle(savedInstanceState)
             if (savedInstanceState.containsKey(KEY_SELECTED_IDS)) {
+                @Suppress("DEPRECATION")
                 selectedIds = savedInstanceState.getParcelableArrayList<Identifier>(
                     KEY_SELECTED_IDS
                 )?.map { it } ?: emptyList()
@@ -193,6 +194,7 @@ internal class MediaPickerFragment : Fragment() {
             NUM_COLUMNS
         )
 
+        @Suppress("DEPRECATION")
         savedInstanceState?.getParcelable<Parcelable>(KEY_LIST_STATE)?.let {
             layoutManager.onRestoreInstanceState(it)
         }

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/MediaViewerFragment.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/MediaViewerFragment.kt
@@ -71,6 +71,7 @@ internal class MediaViewerFragment :
         _binding = MediaPickerLibViewerFragmentBinding.bind(view)
 
         binding.iconBack.setOnClickListener {
+            @Suppress("DEPRECATION")
             activity?.onBackPressed()
         }
         loadImage()

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/MediaViewerFragment.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/MediaViewerFragment.kt
@@ -15,8 +15,7 @@ import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.request.RequestListener
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.mediapicker.R.id
-import org.wordpress.android.mediapicker.R.layout
+import org.wordpress.android.mediapicker.R
 import org.wordpress.android.mediapicker.databinding.MediaPickerLibViewerFragmentBinding
 
 /**
@@ -24,7 +23,7 @@ import org.wordpress.android.mediapicker.databinding.MediaPickerLibViewerFragmen
  */
 @AndroidEntryPoint
 internal class MediaViewerFragment :
-    Fragment(layout.media_picker_lib_viewer_fragment),
+    Fragment(R.layout.media_picker_lib_viewer_fragment),
     RequestListener<Drawable> {
     companion object {
         const val IMAGE_URL_KEY = "image_url_key"
@@ -36,7 +35,7 @@ internal class MediaViewerFragment :
             fragment.arguments = Bundle().apply { putString(IMAGE_URL_KEY, url) }
             activity.supportFragmentManager.beginTransaction()
                 .add(
-                    id.fragment_container,
+                    R.id.fragment_container,
                     fragment,
                     VIEWER_FRAGMENT_TAG
                 )

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/FileThumbnailViewHolder.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/FileThumbnailViewHolder.kt
@@ -4,18 +4,17 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
-import org.wordpress.android.mediapicker.R.id
-import org.wordpress.android.mediapicker.R.layout
+import org.wordpress.android.mediapicker.R
 import org.wordpress.android.mediapicker.model.MediaPickerUiItem
 import org.wordpress.android.mediapicker.util.MediaThumbnailViewUtils
 
 internal class FileThumbnailViewHolder(parent: ViewGroup, private val mediaThumbnailViewUtils: MediaThumbnailViewUtils) :
-    ThumbnailViewHolder(parent, layout.media_picker_lib_file_item) {
-    private val container: View = itemView.findViewById(id.media_grid_item_file_container)
-    private val imgThumbnail: ImageView = itemView.findViewById(id.media_item_filetype_image)
-    private val fileType: TextView = itemView.findViewById(id.media_item_filetype)
-    private val fileName: TextView = itemView.findViewById(id.media_item_name)
-    private val txtSelectionCount: TextView = itemView.findViewById(id.text_selection_count)
+    ThumbnailViewHolder(parent, R.layout.media_picker_lib_file_item) {
+    private val container: View = itemView.findViewById(R.id.media_grid_item_file_container)
+    private val imgThumbnail: ImageView = itemView.findViewById(R.id.media_item_filetype_image)
+    private val fileType: TextView = itemView.findViewById(R.id.media_item_filetype)
+    private val fileName: TextView = itemView.findViewById(R.id.media_item_name)
+    private val txtSelectionCount: TextView = itemView.findViewById(R.id.text_selection_count)
 
     fun bind(item: MediaPickerUiItem.FileItem, animateSelection: Boolean, updateCount: Boolean) {
         val isSelected = item.isSelected

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/LoaderViewHolder.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/LoaderViewHolder.kt
@@ -4,14 +4,13 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import androidx.recyclerview.widget.StaggeredGridLayoutManager.LayoutParams
-import org.wordpress.android.mediapicker.R.id
-import org.wordpress.android.mediapicker.R.layout
+import org.wordpress.android.mediapicker.R
 import org.wordpress.android.mediapicker.model.MediaPickerUiItem
 
 internal class LoaderViewHolder(parent: ViewGroup) :
-    ThumbnailViewHolder(parent, layout.media_picker_lib_loader_item) {
-    private val progress: View = itemView.findViewById(id.progress)
-    private val retry: Button = itemView.findViewById(id.button)
+    ThumbnailViewHolder(parent, R.layout.media_picker_lib_loader_item) {
+    private val progress: View = itemView.findViewById(R.id.progress)
+    private val retry: Button = itemView.findViewById(R.id.button)
     fun bind(item: MediaPickerUiItem.NextPageLoader) {
         setFullWidth()
         if (item.isLoading) {

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/PhotoThumbnailViewHolder.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/PhotoThumbnailViewHolder.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.mediapicker.model.MediaPickerUiItem
 import org.wordpress.android.mediapicker.util.MediaThumbnailViewUtils
 import org.wordpress.android.mediapicker.util.cancelRequestAndClearImageView
 import org.wordpress.android.mediapicker.util.load
+import org.wordpress.android.mediapicker.api.R as MPApiR
 
 /*
  * ViewHolder containing a device thumbnail
@@ -33,7 +34,7 @@ internal class PhotoThumbnailViewHolder(
             return
         }
         imgThumbnail.cancelRequestAndClearImageView()
-        imgThumbnail.load(item.url, org.wordpress.android.mediapicker.api.R.color.placeholder)
+        imgThumbnail.load(item.url, MPApiR.color.placeholder)
         mediaThumbnailViewUtils.setupListeners(
             imgThumbnail, item.isSelected,
             item.toggleAction,

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/PhotoThumbnailViewHolder.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/PhotoThumbnailViewHolder.kt
@@ -33,7 +33,7 @@ internal class PhotoThumbnailViewHolder(
             return
         }
         imgThumbnail.cancelRequestAndClearImageView()
-        imgThumbnail.load(item.url, R.color.placeholder)
+        imgThumbnail.load(item.url, org.wordpress.android.mediapicker.api.R.color.placeholder)
         mediaThumbnailViewUtils.setupListeners(
             imgThumbnail, item.isSelected,
             item.toggleAction,

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/VideoThumbnailViewHolder.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/VideoThumbnailViewHolder.kt
@@ -4,7 +4,6 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import org.wordpress.android.mediapicker.R
-import org.wordpress.android.mediapicker.R.layout
 import org.wordpress.android.mediapicker.model.MediaPickerUiItem
 import org.wordpress.android.mediapicker.util.MediaThumbnailViewUtils
 import org.wordpress.android.mediapicker.util.cancelRequestAndClearImageView
@@ -17,7 +16,7 @@ internal class VideoThumbnailViewHolder(
     private val mediaThumbnailViewUtils: MediaThumbnailViewUtils
 ) : ThumbnailViewHolder(
     parent,
-    layout.media_picker_lib_thumbnail_item
+    R.layout.media_picker_lib_thumbnail_item
 ) {
     private val imgThumbnail: ImageView = itemView.findViewById(R.id.image_thumbnail)
     private val txtSelectionCount: TextView = itemView.findViewById(R.id.text_selection_count)

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaPickerPermissionUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaPickerPermissionUtils.kt
@@ -15,7 +15,7 @@ import androidx.core.content.ContextCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
 import org.wordpress.android.mediapicker.Key
 import org.wordpress.android.mediapicker.Permissions
-import org.wordpress.android.mediapicker.R.string
+import org.wordpress.android.mediapicker.R
 import org.wordpress.android.mediapicker.api.Log
 import org.wordpress.android.mediapicker.api.Tracker
 import org.wordpress.android.mediapicker.api.Tracker.Event
@@ -188,13 +188,13 @@ internal class MediaPickerPermissionUtils @Inject constructor(
             WRITE_STORAGE,
             READ_STORAGE ->
                 if (VERSION.SDK_INT > VERSION_CODES.Q)
-                    string.permission_files_and_media
+                    R.string.permission_files_and_media
                 else
-                    string.permission_storage
-            CAMERA -> string.permission_camera
-            IMAGES -> string.permission_photos_videos
-            VIDEOS -> string.permission_photos_videos
-            MUSIC -> string.permission_audio
+                    R.string.permission_storage
+            CAMERA -> R.string.permission_camera
+            IMAGES -> R.string.permission_photos_videos
+            VIDEOS -> R.string.permission_photos_videos
+            MUSIC -> R.string.permission_audio
         }
         return context.getString(resource)
     }

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaThumbnailViewUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaThumbnailViewUtils.kt
@@ -7,7 +7,8 @@ import org.wordpress.android.mediapicker.R
 import org.wordpress.android.mediapicker.model.MediaPickerUiItem.LongClickAction
 import org.wordpress.android.mediapicker.model.MediaPickerUiItem.ToggleAction
 import org.wordpress.android.util.ViewUtils
-import java.util.Locale
+import java.util.*
+import org.wordpress.android.mediapicker.api.R as MPApiR
 
 internal class MediaThumbnailViewUtils {
     fun setupListeners(
@@ -43,7 +44,7 @@ internal class MediaThumbnailViewUtils {
 
         // not an image or video, so show file name and file type
         val placeholderResId = MediaUtils.getPlaceholder(fileName)
-        imgThumbnail.setImageResourceWithTint(placeholderResId, org.wordpress.android.mediapicker.api.R.color.neutral_30)
+        imgThumbnail.setImageResourceWithTint(placeholderResId, MPApiR.color.neutral_30)
 
         container.setOnClickListener {
             toggleAction.toggle()

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaThumbnailViewUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaThumbnailViewUtils.kt
@@ -43,7 +43,7 @@ internal class MediaThumbnailViewUtils {
 
         // not an image or video, so show file name and file type
         val placeholderResId = MediaUtils.getPlaceholder(fileName)
-        imgThumbnail.setImageResourceWithTint(placeholderResId, R.color.neutral_30)
+        imgThumbnail.setImageResourceWithTint(placeholderResId, org.wordpress.android.mediapicker.api.R.color.neutral_30)
 
         container.setOnClickListener {
             toggleAction.toggle()

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaUtils.kt
@@ -2,33 +2,32 @@ package org.wordpress.android.mediapicker.util
 
 import android.content.Intent
 import android.net.Uri
-import org.wordpress.android.mediapicker.R.drawable
+import org.wordpress.android.mediapicker.R
 import org.wordpress.android.util.MediaUtils
-import java.util.ArrayList
 
 object MediaUtils {
     fun getPlaceholder(url: String?): Int {
         return when {
             MediaUtils.isValidImage(url) -> {
-                drawable.ic_image_white_24dp
+                R.drawable.ic_image_white_24dp
             }
             MediaUtils.isDocument(url) -> {
-                drawable.ic_pages_white_24dp
+                R.drawable.ic_pages_white_24dp
             }
             MediaUtils.isPowerpoint(url) -> {
-                drawable.media_powerpoint
+                R.drawable.media_powerpoint
             }
             MediaUtils.isSpreadsheet(url) -> {
-                drawable.media_spreadsheet
+                R.drawable.media_spreadsheet
             }
             MediaUtils.isVideo(url) -> {
-                drawable.ic_video_camera_white_24dp
+                R.drawable.ic_video_camera_white_24dp
             }
             MediaUtils.isAudio(url) -> {
-                drawable.ic_audio_white_24dp
+                R.drawable.ic_audio_white_24dp
             }
             else -> {
-                drawable.ic_image_multiple_white_24dp
+                R.drawable.ic_image_multiple_white_24dp
             }
         }
     }

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/viewmodel/MediaPickerViewModel.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/viewmodel/MediaPickerViewModel.kt
@@ -85,6 +85,7 @@ import org.wordpress.android.mediapicker.util.MediaPickerPermissionUtils
 import org.wordpress.android.mediapicker.util.distinct
 import org.wordpress.android.mediapicker.util.merge
 import javax.inject.Inject
+import org.wordpress.android.mediapicker.api.R as MPApiR
 
 @Suppress("LargeClass")
 @HiltViewModel
@@ -287,7 +288,7 @@ internal class MediaPickerViewModel @Inject constructor(
                 Empty(
                     title,
                     htmlSubtitle,
-                    image ?: org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_empty_search_image,
+                    image ?: MPApiR.drawable.media_picker_lib_empty_search_image,
                     bottomImage,
                     bottomImageDescription,
                     isSearching == true,
@@ -303,7 +304,7 @@ internal class MediaPickerViewModel @Inject constructor(
         } else {
             Empty(
                 UiStringRes(R.string.media_empty_list),
-                image = org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_empty_gallery_image,
+                image = MPApiR.drawable.media_picker_lib_empty_gallery_image,
                 isSearching = isSearching == true
             )
         }

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/viewmodel/MediaPickerViewModel.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/viewmodel/MediaPickerViewModel.kt
@@ -287,7 +287,7 @@ internal class MediaPickerViewModel @Inject constructor(
                 Empty(
                     title,
                     htmlSubtitle,
-                    image ?: R.drawable.media_picker_lib_empty_search_image,
+                    image ?: org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_empty_search_image,
                     bottomImage,
                     bottomImageDescription,
                     isSearching == true,
@@ -303,7 +303,7 @@ internal class MediaPickerViewModel @Inject constructor(
         } else {
             Empty(
                 UiStringRes(R.string.media_empty_list),
-                image = R.drawable.media_picker_lib_empty_gallery_image,
+                image = org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_empty_gallery_image,
                 isSearching = isSearching == true
             )
         }

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/viewmodel/MediaPickerViewModel.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/viewmodel/MediaPickerViewModel.kt
@@ -14,8 +14,7 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.mediapicker.MediaManager
 import org.wordpress.android.mediapicker.MediaPickerTracker
 import org.wordpress.android.mediapicker.MediaPickerUtils
-import org.wordpress.android.mediapicker.R.drawable
-import org.wordpress.android.mediapicker.R.string
+import org.wordpress.android.mediapicker.R
 import org.wordpress.android.mediapicker.api.MediaPickerSetup
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.SYSTEM_PICKER
@@ -288,7 +287,7 @@ internal class MediaPickerViewModel @Inject constructor(
                 Empty(
                     title,
                     htmlSubtitle,
-                    image ?: drawable.media_picker_lib_empty_search_image,
+                    image ?: R.drawable.media_picker_lib_empty_search_image,
                     bottomImage,
                     bottomImageDescription,
                     isSearching == true,
@@ -303,8 +302,8 @@ internal class MediaPickerViewModel @Inject constructor(
             Loading
         } else {
             Empty(
-                UiStringRes(string.media_empty_list),
-                image = drawable.media_picker_lib_empty_gallery_image,
+                UiStringRes(R.string.media_empty_list),
+                image = R.drawable.media_picker_lib_empty_gallery_image,
                 isSearching = isSearching == true
             )
         }
@@ -322,7 +321,7 @@ internal class MediaPickerViewModel @Inject constructor(
             mediaPickerSetup.isMultiSelectEnabled -> {
                 UiString.UiStringText(
                     String.format(
-                        resourceProvider.getString(string.add_count),
+                        resourceProvider.getString(R.string.add_count),
                         numSelected
                     )
                 )
@@ -332,13 +331,13 @@ internal class MediaPickerViewModel @Inject constructor(
                 val isVideoPicker = mediaPickerSetup.allowedTypes.contains(VIDEO)
                 val isAudioPicker = mediaPickerSetup.allowedTypes.contains(AUDIO)
                 if (isImagePicker && isVideoPicker) {
-                    UiStringRes(string.photo_picker_use_media)
+                    UiStringRes(R.string.photo_picker_use_media)
                 } else if (isVideoPicker) {
-                    UiStringRes(string.photo_picker_use_video)
+                    UiStringRes(R.string.photo_picker_use_video)
                 } else if (isAudioPicker) {
-                    UiStringRes(string.photo_picker_use_audio)
+                    UiStringRes(R.string.photo_picker_use_audio)
                 } else {
-                    UiStringRes(string.photo_picker_use_photo)
+                    UiStringRes(R.string.photo_picker_use_photo)
                 }
             }
         }
@@ -636,14 +635,14 @@ internal class MediaPickerViewModel @Inject constructor(
                 }.distinct().joinToString(" & ")
 
             val labelStringResource = if (softAskRequest.isAlwaysDenied)
-                string.media_picker_soft_ask_permissions_denied
+                R.string.media_picker_soft_ask_permissions_denied
             else
-                string.media_picker_soft_ask_permissions_request
+                R.string.media_picker_soft_ask_permissions_request
             val label = resourceProvider.getString(labelStringResource, permissionNames)
             val buttonStringResource = if (softAskRequest.isAlwaysDenied) {
-                string.button_edit_permissions
+                R.string.button_edit_permissions
             } else {
-                string.photo_picker_soft_ask_allow
+                R.string.photo_picker_soft_ask_allow
             }
 
             return SoftAskViewUiModel.Visible(

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -62,7 +62,7 @@ dependencies {
 
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
-    implementation "com.google.android.material:material:$materialVersion"
+    implementation "com.google.android.material:material:$googleMaterialVersion"
 
     implementation "com.google.dagger:hilt-android:$gradle.ext.daggerVersion"
     implementation "com.google.dagger:hilt-android-compiler:$gradle.ext.daggerVersion"

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -13,7 +13,6 @@ repositories {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion rootProject.buildToolsVersion
 
     defaultConfig {
         applicationId "org.wordpress.android.sampleapp"

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -60,7 +60,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
 
-    implementation "androidx.core:core-ktx:$coreVersion"
+    implementation "androidx.core:core-ktx:$androidxCoreVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
     implementation "com.google.android.material:material:$materialVersion"
 

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation project(':mediapicker:source-gif')
     implementation project(':mediapicker:source-wordpress')
 
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinxCoroutinesVersion"
 
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$appcompatVersion"
     implementation "com.google.android.material:material:$materialVersion"
 
-    implementation "com.google.dagger:hilt-android:$daggerVersion"
-    implementation "com.google.dagger:hilt-android-compiler:$daggerVersion"
-    kapt "com.google.dagger:hilt-compiler:$daggerVersion"
+    implementation "com.google.dagger:hilt-android:$gradle.ext.daggerVersion"
+    implementation "com.google.dagger:hilt-android-compiler:$gradle.ext.daggerVersion"
+    kapt "com.google.dagger:hilt-compiler:$gradle.ext.daggerVersion"
 }

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
 
     implementation "androidx.core:core-ktx:$coreVersion"
-    implementation "androidx.appcompat:appcompat:$appcompatVersion"
+    implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
     implementation "com.google.android.material:material:$materialVersion"
 
     implementation "com.google.dagger:hilt-android:$gradle.ext.daggerVersion"

--- a/sampleapp/src/main/java/org/wordpress/android/sampleapp/MainActivity.kt
+++ b/sampleapp/src/main/java/org/wordpress/android/sampleapp/MainActivity.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.DEVICE
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.GIF_LIBRARY
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.SYSTEM_PICKER
 import org.wordpress.android.mediapicker.ui.MediaPickerActivity
-import org.wordpress.android.sampleapp.R.id
 import org.wordpress.android.sampleapp.databinding.ActivityMainBinding
 import javax.inject.Inject
 
@@ -90,7 +89,7 @@ class MainActivity : AppCompatActivity() {
                     ?.map { mediaPickerUtils.getFilePath(Uri.parse(it)) }
                     ?.joinToString("\n") ?: ""
 
-                Snackbar.make(findViewById<Button>(id.content), files, Snackbar.LENGTH_LONG).show()
+                Snackbar.make(findViewById<Button>(R.id.content), files, Snackbar.LENGTH_LONG).show()
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,7 @@ pluginManagement {
     gradle.ext.daggerVersion = '2.42'
     gradle.ext.agpVersion = '7.2.1'
     gradle.ext.detektVersion = '1.19.0'
+    gradle.ext.automatticPublishToS3Version = '0.7.0'
 
     plugins {
         id 'io.gitlab.arturbosch.detekt' version gradle.ext.detektVersion
@@ -13,7 +14,7 @@ pluginManagement {
         id "com.android.application" version gradle.ext.agpVersion
         id "com.android.library" version gradle.ext.agpVersion
         id 'dagger.hilt.android.plugin'
-        id "com.automattic.android.publish-to-s3" version "0.7.0"
+        id "com.automattic.android.publish-to-s3" version gradle.ext.automatticPublishToS3Version
     }
     repositories {
         maven {


### PR DESCRIPTION
This PR resolves/suppresses all warnings for all modules and then enables all warnings as errors as the default for this project (a3e3911eca425bda0919535cc035689cf150ca28).

PS: This is done just to restrict further Kotlin related warnings to creep into this repo and with it to also enable future Kotlin updates, for example see below warning that would have made the Kotlin `1.7` update a bit more in the future:

`Non exhaustive 'when' statements on enum will be prohibited in 1.7, add 'XYZ' branches or 'else' branch instead`

-----

Warnings Suppression List:

1. [Suppress all deprecated warnings for mediapicker](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/e530a9726db491b2723c7ac24a7df03b1278c597)

Test Restructure List:

1. [Remove test check from buildkite](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/54e697120b508aa5afb34a7382066aef7c30d523)

Dependency Versions Refactor List:

1. [Extract all sdk version to a separate ext block](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/baa9b6979b12b6052bf6adabb184cd5a51e6c584)
2. [Remove unnecessary build tools version configuration](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/166de801a2c39a208358295fa465a1c9c8f26281)
3. [Remove unnecessary extra dagger version configuration](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/a572bab5b197de7008dd2bca616c35d886bc6d07)
4. [Remove unused hilt version](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/447ba495bc7cd97bf32b83cbe731284f9c34fd61)
5. [Rename lifecycle to androidx lifecycle version](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/c7e0ba26da6f31fd2ea86f3ff6460b1708e0d0d1)
6. [Rename datastore to androidx datastore version](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/c15473cfb5f72ac08d70ee9cb50d198a66a09b08)
7. [Rename swipe refresh layout to androidx swipe to refresh version](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/2bfadeb9b7b0fb75f057cd249c9580cc6825abad)
8. [Rename constraint layout to androidx constraint layout version](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/df7e1cfcba66ceed5b65bd2b41ed958715da7a61)
9. [Rename appcompat to androidx appcompat version](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/dd4e18b24b871cc4debe5ce14d8cf9a94da854ec)
10. [Rename core to androidx core version](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/348603954e852b20c1eb50f261f35838806bb553)
11. [Rename coroutines to kotlinx coroutines version](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/4123f858850210fe0fe5683619b5856b412f44e9)
12. [Rename material to google material version](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/99cf6603105e1d5e3066403da596487a1e99e0ce)
13. [Rename photoview to chrisbanes photoview version](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/49f965184052cfa6ce72acb50364516dbdae0797)
14. [Rename navigation fragment to androidx navigation version](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/86610a73eaea41752e1a9181c85f7b35561db5ff)
15. [Rename retrofit to squareup retrofit version](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/bacd3e2fa5ca841c00a229a127bc4bc905b27495)
16. [Move wordpress utils version to different version group for libs](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/90785d3cb686fdd9335bdd87dc763c478d16ccd9)
17. [Rename fluxc to wordPress fluxc version](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/64bcf4ad2a2b3e6dcc2b8a48939029a7ef0fc5d6)
18. [Add versions groups to root build gradle](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/commit/179b6fce9bb19aeceeacfb489dea30a0fa4a2e28)

-----

## To test

1. There is nothing much to test here (if not all, most of the deprecated warnings were suppressed).
2. Verifying that all the CI checks are successful should be enough.
3. However, if you want to be thorough about reviewing this change, you could quickly smoke test the `sampleapp` app and see if it is working as expected.