### PR TITLE
[Build] Enable Non-Transitive Resources

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,5 @@ org.gradle.jvmargs=-Xmx1536m
 
 android.useAndroidX=true
 android.enableJetifier=false
+
+android.nonTransitiveRClass=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,8 @@
+# Project-wide Gradle settings.
+
+org.gradle.jvmargs=-Xmx1536m
+
+# WordPress-MediaPicker-Android properties.
+
 android.useAndroidX=true
 android.enableJetifier=false
-org.gradle.jvmargs=-Xmx1536m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project-wide Gradle settings.
 
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx6g
 
 # WordPress-MediaPicker-Android properties.
 

--- a/mediapicker/source-gif/src/main/java/org/wordpress/android/mediapicker/source/gif/GifMediaDataSource.kt
+++ b/mediapicker/source-gif/src/main/java/org/wordpress/android/mediapicker/source/gif/GifMediaDataSource.kt
@@ -36,8 +36,8 @@ class GifMediaDataSource
 
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             return Failure(
-                UiStringRes(R.string.no_network_title),
-                htmlSubtitle = UiStringRes(R.string.no_network_message),
+                UiStringRes(org.wordpress.android.mediapicker.api.R.string.no_network_title),
+                htmlSubtitle = UiStringRes(org.wordpress.android.mediapicker.api.R.string.no_network_message),
                 image = org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_load_error_image,
                 data = items
             )
@@ -70,7 +70,7 @@ class GifMediaDataSource
                             Failure(
                                 UiStringRes(R.string.media_loading_failed),
                                 htmlSubtitle = UiStringText(errorMessage),
-                                image = R.drawable.media_picker_lib_load_error_image,
+                                image = org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_load_error_image,
                                 data = items
                             )
                         )
@@ -87,7 +87,7 @@ class GifMediaDataSource
         return Empty(
             title,
             null,
-            R.drawable.media_picker_lib_empty_gallery_image,
+            org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_empty_gallery_image,
             R.drawable.img_tenor_100dp,
             UiStringRes(R.string.gif_powered_by_tenor)
         )

--- a/mediapicker/source-gif/src/main/java/org/wordpress/android/mediapicker/source/gif/GifMediaDataSource.kt
+++ b/mediapicker/source-gif/src/main/java/org/wordpress/android/mediapicker/source/gif/GifMediaDataSource.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.mediapicker.source.gif.util.NetworkUtilsWrapper
 import javax.inject.Inject
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
+import org.wordpress.android.mediapicker.api.R as MPApiR
 
 class GifMediaDataSource
 @Inject constructor(
@@ -36,9 +37,9 @@ class GifMediaDataSource
 
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             return Failure(
-                UiStringRes(org.wordpress.android.mediapicker.api.R.string.no_network_title),
-                htmlSubtitle = UiStringRes(org.wordpress.android.mediapicker.api.R.string.no_network_message),
-                image = org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_load_error_image,
+                UiStringRes(MPApiR.string.no_network_title),
+                htmlSubtitle = UiStringRes(MPApiR.string.no_network_message),
+                image = MPApiR.drawable.media_picker_lib_load_error_image,
                 data = items
             )
         }
@@ -70,7 +71,7 @@ class GifMediaDataSource
                             Failure(
                                 UiStringRes(R.string.media_loading_failed),
                                 htmlSubtitle = UiStringText(errorMessage),
-                                image = org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_load_error_image,
+                                image = MPApiR.drawable.media_picker_lib_load_error_image,
                                 data = items
                             )
                         )
@@ -87,7 +88,7 @@ class GifMediaDataSource
         return Empty(
             title,
             null,
-            org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_empty_gallery_image,
+            MPApiR.drawable.media_picker_lib_empty_gallery_image,
             R.drawable.img_tenor_100dp,
             UiStringRes(R.string.gif_powered_by_tenor)
         )

--- a/mediapicker/source-gif/src/main/java/org/wordpress/android/mediapicker/source/gif/GifMediaDataSource.kt
+++ b/mediapicker/source-gif/src/main/java/org/wordpress/android/mediapicker/source/gif/GifMediaDataSource.kt
@@ -7,7 +7,6 @@ import org.wordpress.android.mediapicker.api.MediaSource.MediaLoadingResult
 import org.wordpress.android.mediapicker.api.MediaSource.MediaLoadingResult.Empty
 import org.wordpress.android.mediapicker.api.MediaSource.MediaLoadingResult.Failure
 import org.wordpress.android.mediapicker.api.MediaSource.MediaLoadingResult.Success
-import org.wordpress.android.mediapicker.api.R.drawable
 import org.wordpress.android.mediapicker.model.MediaItem
 import org.wordpress.android.mediapicker.model.MediaItem.Identifier.GifMedia
 import org.wordpress.android.mediapicker.model.MediaType.IMAGE
@@ -39,7 +38,7 @@ class GifMediaDataSource
             return Failure(
                 UiStringRes(R.string.no_network_title),
                 htmlSubtitle = UiStringRes(R.string.no_network_message),
-                image = drawable.media_picker_lib_load_error_image,
+                image = org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_load_error_image,
                 data = items
             )
         }

--- a/mediapicker/source-wordpress/src/main/java/org/wordpress/android/mediapicker/source/wordpress/MediaLibrarySource.kt
+++ b/mediapicker/source-wordpress/src/main/java/org/wordpress/android/mediapicker/source/wordpress/MediaLibrarySource.kt
@@ -55,9 +55,9 @@ class MediaLibrarySource(
     ): MediaLoadingResult {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             return Failure(
-                UiStringRes(R.string.no_network_title),
+                UiStringRes(org.wordpress.android.mediapicker.api.R.string.no_network_title),
                 htmlSubtitle = UiStringRes(R.string.no_network_message),
-                image = R.drawable.img_illustration_cloud_off_152dp,
+                image = org.wordpress.android.mediapicker.api.R.drawable.img_illustration_cloud_off_152dp,
                 data = if (loadMore) get(mediaTypes, filter) else listOf()
             )
         }
@@ -86,7 +86,7 @@ class MediaLibrarySource(
                 Failure(
                     UiStringRes(R.string.media_loading_failed),
                     htmlSubtitle = UiStringText(error),
-                    image = R.drawable.img_illustration_cloud_off_152dp,
+                    image = org.wordpress.android.mediapicker.api.R.drawable.img_illustration_cloud_off_152dp,
                     data = if (loadMore) get(mediaTypes, filter) else listOf()
                 )
             } else {
@@ -95,8 +95,8 @@ class MediaLibrarySource(
                     MediaLoadingResult.Success(data, hasMore)
                 } else {
                     Empty(
-                        UiStringRes(R.string.media_empty_search_list),
-                        image = R.drawable.img_illustration_empty_results_216dp
+                        UiStringRes(org.wordpress.android.mediapicker.api.R.string.media_empty_search_list),
+                        image = org.wordpress.android.mediapicker.api.R.drawable.img_illustration_empty_results_216dp
                     )
                 }
             }

--- a/mediapicker/source-wordpress/src/main/java/org/wordpress/android/mediapicker/source/wordpress/MediaLibrarySource.kt
+++ b/mediapicker/source-wordpress/src/main/java/org/wordpress/android/mediapicker/source/wordpress/MediaLibrarySource.kt
@@ -33,6 +33,7 @@ import javax.inject.Inject
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
+import org.wordpress.android.mediapicker.api.R as MPApiR
 
 class MediaLibrarySource(
     private val mediaStore: MediaStore,
@@ -55,9 +56,9 @@ class MediaLibrarySource(
     ): MediaLoadingResult {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             return Failure(
-                UiStringRes(org.wordpress.android.mediapicker.api.R.string.no_network_title),
+                UiStringRes(MPApiR.string.no_network_title),
                 htmlSubtitle = UiStringRes(R.string.no_network_message),
-                image = org.wordpress.android.mediapicker.api.R.drawable.img_illustration_cloud_off_152dp,
+                image = MPApiR.drawable.img_illustration_cloud_off_152dp,
                 data = if (loadMore) get(mediaTypes, filter) else listOf()
             )
         }
@@ -86,7 +87,7 @@ class MediaLibrarySource(
                 Failure(
                     UiStringRes(R.string.media_loading_failed),
                     htmlSubtitle = UiStringText(error),
-                    image = org.wordpress.android.mediapicker.api.R.drawable.img_illustration_cloud_off_152dp,
+                    image = MPApiR.drawable.img_illustration_cloud_off_152dp,
                     data = if (loadMore) get(mediaTypes, filter) else listOf()
                 )
             } else {
@@ -95,8 +96,8 @@ class MediaLibrarySource(
                     MediaLoadingResult.Success(data, hasMore)
                 } else {
                     Empty(
-                        UiStringRes(org.wordpress.android.mediapicker.api.R.string.media_empty_search_list),
-                        image = org.wordpress.android.mediapicker.api.R.drawable.img_illustration_empty_results_216dp
+                        UiStringRes(MPApiR.string.media_empty_search_list),
+                        image = MPApiR.drawable.img_illustration_empty_results_216dp
                     )
                 }
             }

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/MediaPickerActionModeCallback.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/MediaPickerActionModeCallback.kt
@@ -9,9 +9,7 @@ import androidx.lifecycle.Lifecycle.Event.ON_START
 import androidx.lifecycle.Lifecycle.Event.ON_STOP
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
-import androidx.lifecycle.Observer
 import org.wordpress.android.mediapicker.R
-import org.wordpress.android.mediapicker.R.id
 import org.wordpress.android.mediapicker.model.UiStateModels.ActionModeUiModel
 import org.wordpress.android.mediapicker.model.UiString.UiStringRes
 import org.wordpress.android.mediapicker.model.UiString.UiStringText
@@ -29,7 +27,7 @@ internal class MediaPickerActionModeCallback(private val viewModel: MediaPickerV
         lifecycleRegistry.handleLifecycleEvent(ON_START)
         val inflater = actionMode.menuInflater
         inflater.inflate(R.menu.media_picker_lib_action_mode, menu)
-        val doneItem = menu.findItem(id.mnu_confirm_selection)
+        val doneItem = menu.findItem(R.id.mnu_confirm_selection)
 
         actionMode.setTitle(viewModel.title)
         viewModel.uiState.observe(this) { uiState ->
@@ -62,7 +60,7 @@ internal class MediaPickerActionModeCallback(private val viewModel: MediaPickerV
         item: MenuItem
     ): Boolean {
         return when (item.itemId) {
-            id.mnu_confirm_selection -> {
+            R.id.mnu_confirm_selection -> {
                 viewModel.onSelectionConfirmed()
                 true
             }

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/MediaPickerActivity.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/MediaPickerActivity.kt
@@ -7,7 +7,7 @@ import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.mediapicker.R.drawable
+import org.wordpress.android.mediapicker.R
 import org.wordpress.android.mediapicker.api.Log
 import org.wordpress.android.mediapicker.api.MediaPickerSetup
 import org.wordpress.android.mediapicker.databinding.MediaPickerLibActivityBinding
@@ -21,7 +21,7 @@ class MediaPickerActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         val binding = MediaPickerLibActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        binding.toolbarMain.setNavigationIcon(drawable.ic_close_white_24dp)
+        binding.toolbarMain.setNavigationIcon(R.drawable.ic_close_white_24dp)
         setSupportActionBar(binding.toolbarMain)
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/MediaViewerFragment.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/MediaViewerFragment.kt
@@ -15,8 +15,7 @@ import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.request.RequestListener
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.mediapicker.R.id
-import org.wordpress.android.mediapicker.R.layout
+import org.wordpress.android.mediapicker.R
 import org.wordpress.android.mediapicker.databinding.MediaPickerLibViewerFragmentBinding
 
 /**
@@ -24,7 +23,7 @@ import org.wordpress.android.mediapicker.databinding.MediaPickerLibViewerFragmen
  */
 @AndroidEntryPoint
 internal class MediaViewerFragment :
-    Fragment(layout.media_picker_lib_viewer_fragment),
+    Fragment(R.layout.media_picker_lib_viewer_fragment),
     RequestListener<Drawable> {
     companion object {
         const val IMAGE_URL_KEY = "image_url_key"
@@ -36,7 +35,7 @@ internal class MediaViewerFragment :
             fragment.arguments = Bundle().apply { putString(IMAGE_URL_KEY, url) }
             activity.supportFragmentManager.beginTransaction()
                 .add(
-                    id.fragment_container,
+                    R.id.fragment_container,
                     fragment,
                     VIEWER_FRAGMENT_TAG
                 )

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/FileThumbnailViewHolder.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/FileThumbnailViewHolder.kt
@@ -4,18 +4,17 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
-import org.wordpress.android.mediapicker.R.id
-import org.wordpress.android.mediapicker.R.layout
+import org.wordpress.android.mediapicker.R
 import org.wordpress.android.mediapicker.model.MediaPickerUiItem
 import org.wordpress.android.mediapicker.util.MediaThumbnailViewUtils
 
 internal class FileThumbnailViewHolder(parent: ViewGroup, private val mediaThumbnailViewUtils: MediaThumbnailViewUtils) :
-    ThumbnailViewHolder(parent, layout.media_picker_lib_file_item) {
-    private val container: View = itemView.findViewById(id.media_grid_item_file_container)
-    private val imgThumbnail: ImageView = itemView.findViewById(id.media_item_filetype_image)
-    private val fileType: TextView = itemView.findViewById(id.media_item_filetype)
-    private val fileName: TextView = itemView.findViewById(id.media_item_name)
-    private val txtSelectionCount: TextView = itemView.findViewById(id.text_selection_count)
+    ThumbnailViewHolder(parent, R.layout.media_picker_lib_file_item) {
+    private val container: View = itemView.findViewById(R.id.media_grid_item_file_container)
+    private val imgThumbnail: ImageView = itemView.findViewById(R.id.media_item_filetype_image)
+    private val fileType: TextView = itemView.findViewById(R.id.media_item_filetype)
+    private val fileName: TextView = itemView.findViewById(R.id.media_item_name)
+    private val txtSelectionCount: TextView = itemView.findViewById(R.id.text_selection_count)
 
     fun bind(item: MediaPickerUiItem.FileItem, animateSelection: Boolean, updateCount: Boolean) {
         val isSelected = item.isSelected

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/LoaderViewHolder.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/LoaderViewHolder.kt
@@ -4,14 +4,13 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import androidx.recyclerview.widget.StaggeredGridLayoutManager.LayoutParams
-import org.wordpress.android.mediapicker.R.id
-import org.wordpress.android.mediapicker.R.layout
+import org.wordpress.android.mediapicker.R
 import org.wordpress.android.mediapicker.model.MediaPickerUiItem
 
 internal class LoaderViewHolder(parent: ViewGroup) :
-    ThumbnailViewHolder(parent, layout.media_picker_lib_loader_item) {
-    private val progress: View = itemView.findViewById(id.progress)
-    private val retry: Button = itemView.findViewById(id.button)
+    ThumbnailViewHolder(parent, R.layout.media_picker_lib_loader_item) {
+    private val progress: View = itemView.findViewById(R.id.progress)
+    private val retry: Button = itemView.findViewById(R.id.button)
     fun bind(item: MediaPickerUiItem.NextPageLoader) {
         setFullWidth()
         if (item.isLoading) {

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/PhotoThumbnailViewHolder.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/PhotoThumbnailViewHolder.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.mediapicker.model.MediaPickerUiItem
 import org.wordpress.android.mediapicker.util.MediaThumbnailViewUtils
 import org.wordpress.android.mediapicker.util.cancelRequestAndClearImageView
 import org.wordpress.android.mediapicker.util.load
+import org.wordpress.android.mediapicker.api.R as MPApiR
 
 /*
  * ViewHolder containing a device thumbnail
@@ -33,7 +34,7 @@ internal class PhotoThumbnailViewHolder(
             return
         }
         imgThumbnail.cancelRequestAndClearImageView()
-        imgThumbnail.load(item.url, org.wordpress.android.mediapicker.api.R.color.placeholder)
+        imgThumbnail.load(item.url, MPApiR.color.placeholder)
         mediaThumbnailViewUtils.setupListeners(
             imgThumbnail, item.isSelected,
             item.toggleAction,

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/PhotoThumbnailViewHolder.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/PhotoThumbnailViewHolder.kt
@@ -33,7 +33,7 @@ internal class PhotoThumbnailViewHolder(
             return
         }
         imgThumbnail.cancelRequestAndClearImageView()
-        imgThumbnail.load(item.url, R.color.placeholder)
+        imgThumbnail.load(item.url, org.wordpress.android.mediapicker.api.R.color.placeholder)
         mediaThumbnailViewUtils.setupListeners(
             imgThumbnail, item.isSelected,
             item.toggleAction,

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/VideoThumbnailViewHolder.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/VideoThumbnailViewHolder.kt
@@ -4,7 +4,6 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import org.wordpress.android.mediapicker.R
-import org.wordpress.android.mediapicker.R.layout
 import org.wordpress.android.mediapicker.model.MediaPickerUiItem
 import org.wordpress.android.mediapicker.util.MediaThumbnailViewUtils
 import org.wordpress.android.mediapicker.util.cancelRequestAndClearImageView
@@ -17,7 +16,7 @@ internal class VideoThumbnailViewHolder(
     private val mediaThumbnailViewUtils: MediaThumbnailViewUtils
 ) : ThumbnailViewHolder(
     parent,
-    layout.media_picker_lib_thumbnail_item
+    R.layout.media_picker_lib_thumbnail_item
 ) {
     private val imgThumbnail: ImageView = itemView.findViewById(R.id.image_thumbnail)
     private val txtSelectionCount: TextView = itemView.findViewById(R.id.text_selection_count)

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaPickerPermissionUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaPickerPermissionUtils.kt
@@ -15,7 +15,7 @@ import androidx.core.content.ContextCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
 import org.wordpress.android.mediapicker.Key
 import org.wordpress.android.mediapicker.Permissions
-import org.wordpress.android.mediapicker.R.string
+import org.wordpress.android.mediapicker.R
 import org.wordpress.android.mediapicker.api.Log
 import org.wordpress.android.mediapicker.api.Tracker
 import org.wordpress.android.mediapicker.api.Tracker.Event
@@ -188,13 +188,13 @@ internal class MediaPickerPermissionUtils @Inject constructor(
             WRITE_STORAGE,
             READ_STORAGE ->
                 if (VERSION.SDK_INT > VERSION_CODES.Q)
-                    string.permission_files_and_media
+                    R.string.permission_files_and_media
                 else
-                    string.permission_storage
-            CAMERA -> string.permission_camera
-            IMAGES -> string.permission_photos_videos
-            VIDEOS -> string.permission_photos_videos
-            MUSIC -> string.permission_audio
+                    R.string.permission_storage
+            CAMERA -> R.string.permission_camera
+            IMAGES -> R.string.permission_photos_videos
+            VIDEOS -> R.string.permission_photos_videos
+            MUSIC -> R.string.permission_audio
         }
         return context.getString(resource)
     }

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaThumbnailViewUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaThumbnailViewUtils.kt
@@ -7,7 +7,8 @@ import org.wordpress.android.mediapicker.R
 import org.wordpress.android.mediapicker.model.MediaPickerUiItem.LongClickAction
 import org.wordpress.android.mediapicker.model.MediaPickerUiItem.ToggleAction
 import org.wordpress.android.util.ViewUtils
-import java.util.Locale
+import java.util.*
+import org.wordpress.android.mediapicker.api.R as MPApiR
 
 internal class MediaThumbnailViewUtils {
     fun setupListeners(
@@ -43,7 +44,7 @@ internal class MediaThumbnailViewUtils {
 
         // not an image or video, so show file name and file type
         val placeholderResId = MediaUtils.getPlaceholder(fileName)
-        imgThumbnail.setImageResourceWithTint(placeholderResId, org.wordpress.android.mediapicker.api.R.color.neutral_30)
+        imgThumbnail.setImageResourceWithTint(placeholderResId, MPApiR.color.neutral_30)
 
         container.setOnClickListener {
             toggleAction.toggle()

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaThumbnailViewUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaThumbnailViewUtils.kt
@@ -43,7 +43,7 @@ internal class MediaThumbnailViewUtils {
 
         // not an image or video, so show file name and file type
         val placeholderResId = MediaUtils.getPlaceholder(fileName)
-        imgThumbnail.setImageResourceWithTint(placeholderResId, R.color.neutral_30)
+        imgThumbnail.setImageResourceWithTint(placeholderResId, org.wordpress.android.mediapicker.api.R.color.neutral_30)
 
         container.setOnClickListener {
             toggleAction.toggle()

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaUtils.kt
@@ -2,33 +2,32 @@ package org.wordpress.android.mediapicker.util
 
 import android.content.Intent
 import android.net.Uri
-import org.wordpress.android.mediapicker.R.drawable
+import org.wordpress.android.mediapicker.R
 import org.wordpress.android.util.MediaUtils
-import java.util.ArrayList
 
 object MediaUtils {
     fun getPlaceholder(url: String?): Int {
         return when {
             MediaUtils.isValidImage(url) -> {
-                drawable.ic_image_white_24dp
+                R.drawable.ic_image_white_24dp
             }
             MediaUtils.isDocument(url) -> {
-                drawable.ic_pages_white_24dp
+                R.drawable.ic_pages_white_24dp
             }
             MediaUtils.isPowerpoint(url) -> {
-                drawable.media_powerpoint
+                R.drawable.media_powerpoint
             }
             MediaUtils.isSpreadsheet(url) -> {
-                drawable.media_spreadsheet
+                R.drawable.media_spreadsheet
             }
             MediaUtils.isVideo(url) -> {
-                drawable.ic_video_camera_white_24dp
+                R.drawable.ic_video_camera_white_24dp
             }
             MediaUtils.isAudio(url) -> {
-                drawable.ic_audio_white_24dp
+                R.drawable.ic_audio_white_24dp
             }
             else -> {
-                drawable.ic_image_multiple_white_24dp
+                R.drawable.ic_image_multiple_white_24dp
             }
         }
     }

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/viewmodel/MediaPickerViewModel.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/viewmodel/MediaPickerViewModel.kt
@@ -85,6 +85,7 @@ import org.wordpress.android.mediapicker.util.MediaPickerPermissionUtils
 import org.wordpress.android.mediapicker.util.distinct
 import org.wordpress.android.mediapicker.util.merge
 import javax.inject.Inject
+import org.wordpress.android.mediapicker.api.R as MPApiR
 
 @Suppress("LargeClass")
 @HiltViewModel
@@ -287,7 +288,7 @@ internal class MediaPickerViewModel @Inject constructor(
                 Empty(
                     title,
                     htmlSubtitle,
-                    image ?: org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_empty_search_image,
+                    image ?: MPApiR.drawable.media_picker_lib_empty_search_image,
                     bottomImage,
                     bottomImageDescription,
                     isSearching == true,
@@ -303,7 +304,7 @@ internal class MediaPickerViewModel @Inject constructor(
         } else {
             Empty(
                 UiStringRes(R.string.media_empty_list),
-                image = org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_empty_gallery_image,
+                image = MPApiR.drawable.media_picker_lib_empty_gallery_image,
                 isSearching = isSearching == true
             )
         }

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/viewmodel/MediaPickerViewModel.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/viewmodel/MediaPickerViewModel.kt
@@ -287,7 +287,7 @@ internal class MediaPickerViewModel @Inject constructor(
                 Empty(
                     title,
                     htmlSubtitle,
-                    image ?: R.drawable.media_picker_lib_empty_search_image,
+                    image ?: org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_empty_search_image,
                     bottomImage,
                     bottomImageDescription,
                     isSearching == true,
@@ -303,7 +303,7 @@ internal class MediaPickerViewModel @Inject constructor(
         } else {
             Empty(
                 UiStringRes(R.string.media_empty_list),
-                image = R.drawable.media_picker_lib_empty_gallery_image,
+                image = org.wordpress.android.mediapicker.api.R.drawable.media_picker_lib_empty_gallery_image,
                 isSearching = isSearching == true
             )
         }

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/viewmodel/MediaPickerViewModel.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/viewmodel/MediaPickerViewModel.kt
@@ -14,8 +14,7 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.mediapicker.MediaManager
 import org.wordpress.android.mediapicker.MediaPickerTracker
 import org.wordpress.android.mediapicker.MediaPickerUtils
-import org.wordpress.android.mediapicker.R.drawable
-import org.wordpress.android.mediapicker.R.string
+import org.wordpress.android.mediapicker.R
 import org.wordpress.android.mediapicker.api.MediaPickerSetup
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.SYSTEM_PICKER
@@ -288,7 +287,7 @@ internal class MediaPickerViewModel @Inject constructor(
                 Empty(
                     title,
                     htmlSubtitle,
-                    image ?: drawable.media_picker_lib_empty_search_image,
+                    image ?: R.drawable.media_picker_lib_empty_search_image,
                     bottomImage,
                     bottomImageDescription,
                     isSearching == true,
@@ -303,8 +302,8 @@ internal class MediaPickerViewModel @Inject constructor(
             Loading
         } else {
             Empty(
-                UiStringRes(string.media_empty_list),
-                image = drawable.media_picker_lib_empty_gallery_image,
+                UiStringRes(R.string.media_empty_list),
+                image = R.drawable.media_picker_lib_empty_gallery_image,
                 isSearching = isSearching == true
             )
         }
@@ -322,7 +321,7 @@ internal class MediaPickerViewModel @Inject constructor(
             mediaPickerSetup.isMultiSelectEnabled -> {
                 UiString.UiStringText(
                     String.format(
-                        resourceProvider.getString(string.add_count),
+                        resourceProvider.getString(R.string.add_count),
                         numSelected
                     )
                 )
@@ -332,13 +331,13 @@ internal class MediaPickerViewModel @Inject constructor(
                 val isVideoPicker = mediaPickerSetup.allowedTypes.contains(VIDEO)
                 val isAudioPicker = mediaPickerSetup.allowedTypes.contains(AUDIO)
                 if (isImagePicker && isVideoPicker) {
-                    UiStringRes(string.photo_picker_use_media)
+                    UiStringRes(R.string.photo_picker_use_media)
                 } else if (isVideoPicker) {
-                    UiStringRes(string.photo_picker_use_video)
+                    UiStringRes(R.string.photo_picker_use_video)
                 } else if (isAudioPicker) {
-                    UiStringRes(string.photo_picker_use_audio)
+                    UiStringRes(R.string.photo_picker_use_audio)
                 } else {
-                    UiStringRes(string.photo_picker_use_photo)
+                    UiStringRes(R.string.photo_picker_use_photo)
                 }
             }
         }
@@ -636,14 +635,14 @@ internal class MediaPickerViewModel @Inject constructor(
                 }.distinct().joinToString(" & ")
 
             val labelStringResource = if (softAskRequest.isAlwaysDenied)
-                string.media_picker_soft_ask_permissions_denied
+                R.string.media_picker_soft_ask_permissions_denied
             else
-                string.media_picker_soft_ask_permissions_request
+                R.string.media_picker_soft_ask_permissions_request
             val label = resourceProvider.getString(labelStringResource, permissionNames)
             val buttonStringResource = if (softAskRequest.isAlwaysDenied) {
-                string.button_edit_permissions
+                R.string.button_edit_permissions
             } else {
-                string.photo_picker_soft_ask_allow
+                R.string.photo_picker_soft_ask_allow
             }
 
             return SoftAskViewUiModel.Visible(

--- a/sampleapp/src/main/java/org/wordpress/android/sampleapp/MainActivity.kt
+++ b/sampleapp/src/main/java/org/wordpress/android/sampleapp/MainActivity.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.DEVICE
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.GIF_LIBRARY
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.SYSTEM_PICKER
 import org.wordpress.android.mediapicker.ui.MediaPickerActivity
-import org.wordpress.android.sampleapp.R.id
 import org.wordpress.android.sampleapp.databinding.ActivityMainBinding
 import javax.inject.Inject
 
@@ -90,7 +89,7 @@ class MainActivity : AppCompatActivity() {
                     ?.map { mediaPickerUtils.getFilePath(Uri.parse(it)) }
                     ?.joinToString("\n") ?: ""
 
-                Snackbar.make(findViewById<Button>(id.content), files, Snackbar.LENGTH_LONG).show()
+                Snackbar.make(findViewById<Button>(R.id.content), files, Snackbar.LENGTH_LONG).show()
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,7 @@ pluginManagement {
     gradle.ext.daggerVersion = '2.42'
     gradle.ext.agpVersion = '7.2.1'
     gradle.ext.detektVersion = '1.19.0'
+    gradle.ext.automatticPublishToS3Version = '0.7.0'
 
     plugins {
         id 'io.gitlab.arturbosch.detekt' version gradle.ext.detektVersion
@@ -13,7 +14,7 @@ pluginManagement {
         id "com.android.application" version gradle.ext.agpVersion
         id "com.android.library" version gradle.ext.agpVersion
         id 'dagger.hilt.android.plugin'
-        id "com.automattic.android.publish-to-s3" version "0.7.0"
+        id "com.automattic.android.publish-to-s3" version gradle.ext.automatticPublishToS3Version
     }
     repositories {
         maven {


### PR DESCRIPTION
This PR is a prerequisite for the `Gradle 8.1.1 & AGP 8.0.2 Upgrade for WPAndroid, WCAndroid & Related Libs` project.

Platform Request: `pdnsEh-13V-p2`
Project Thread: `paaHJt-57Z-p2`

-----

This PR enables non-transitive resources (`android.nonTransitiveRClass`) for the project.

FYI: This behavior becomes the default in AGP `8.0` and higher. As such, this becomes a prerequisite for the AGP `8.0.2` upgrade, that is of course, unless `android.nonTransitiveRClass` is explicitly set to `false`.

-----

Dependency Versions Refactor List:

1. [Extract automattic publish to s3 version to settings build gradle](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/pull/68/commits/5ee4b6fa357a01dccdd420c6edd2641638978092)

-----

## To test:

1. Verify that all the CI checks are successful.
3. Smoke test the app.