### PR TITLE
Ability to select other file types

### DIFF
--- a/mediapicker/domain/src/main/java/org/wordpress/android/mediapicker/api/MediaPickerSetup.kt
+++ b/mediapicker/domain/src/main/java/org/wordpress/android/mediapicker/api/MediaPickerSetup.kt
@@ -4,12 +4,12 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import androidx.annotation.StringRes
-import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.CAMERA
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.DEVICE
 import org.wordpress.android.mediapicker.model.MediaType
 import org.wordpress.android.mediapicker.model.MediaType.AUDIO
 import org.wordpress.android.mediapicker.model.MediaType.IMAGE
 import org.wordpress.android.mediapicker.model.MediaType.VIDEO
+import org.wordpress.android.mediapicker.model.MediaTypes
 
 data class MediaPickerSetup(
     val primaryDataSource: DataSource,
@@ -40,11 +40,15 @@ data class MediaPickerSetup(
     val isAudioPermissionRequired = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             primaryDataSource == DEVICE && allowedTypes.contains(AUDIO)
 
-    val areMediaPermissionsRequired = isImagesPermissionRequired || isVideoPermissionRequired || isAudioPermissionRequired
+    val areMediaPermissionsRequired =
+        isImagesPermissionRequired || isVideoPermissionRequired || isAudioPermissionRequired
 
     fun toBundle(bundle: Bundle) {
         bundle.putInt(KEY_PRIMARY_DATA_SOURCE, primaryDataSource.ordinal)
-        bundle.putIntegerArrayList(KEY_AVAILABLE_DATA_SOURCES, ArrayList(availableDataSources.map { it.ordinal }))
+        bundle.putIntegerArrayList(
+            KEY_AVAILABLE_DATA_SOURCES,
+            ArrayList(availableDataSources.map { it.ordinal })
+        )
         bundle.putIntegerArrayList(KEY_ALLOWED_TYPES, ArrayList(allowedTypes.map { it.ordinal }))
         bundle.putBoolean(KEY_CAN_MULTISELECT, isMultiSelectEnabled)
         bundle.putBoolean(KEY_QUEUE_RESULTS, areResultsQueued)
@@ -54,8 +58,14 @@ data class MediaPickerSetup(
 
     fun toIntent(intent: Intent) {
         intent.putExtra(KEY_PRIMARY_DATA_SOURCE, primaryDataSource.ordinal)
-        intent.putIntegerArrayListExtra(KEY_AVAILABLE_DATA_SOURCES, ArrayList(availableDataSources.map { it.ordinal }))
-        intent.putIntegerArrayListExtra(KEY_ALLOWED_TYPES, ArrayList(allowedTypes.map { it.ordinal }))
+        intent.putIntegerArrayListExtra(
+            KEY_AVAILABLE_DATA_SOURCES,
+            ArrayList(availableDataSources.map { it.ordinal })
+        )
+        intent.putIntegerArrayListExtra(
+            KEY_ALLOWED_TYPES,
+            ArrayList(allowedTypes.map { it.ordinal })
+        )
         intent.putExtra(KEY_CAN_MULTISELECT, isMultiSelectEnabled)
         intent.putExtra(KEY_QUEUE_RESULTS, areResultsQueued)
         intent.putExtra(KEY_SEARCH_MODE, searchMode.ordinal)
@@ -73,12 +83,14 @@ data class MediaPickerSetup(
 
         fun fromBundle(bundle: Bundle): MediaPickerSetup {
             val dataSource = DataSource.values()[bundle.getInt(KEY_PRIMARY_DATA_SOURCE)]
-            val availableDataSources = (bundle.getIntegerArrayList(KEY_AVAILABLE_DATA_SOURCES) ?: listOf<Int>()).map {
-                DataSource.values()[it]
-            }.toSet()
-            val allowedTypes = (bundle.getIntegerArrayList(KEY_ALLOWED_TYPES) ?: listOf<Int>()).map {
-                MediaType.values()[it]
-            }.toSet()
+            val availableDataSources =
+                (bundle.getIntegerArrayList(KEY_AVAILABLE_DATA_SOURCES) ?: listOf<Int>()).map {
+                    DataSource.values()[it]
+                }.toSet()
+            val allowedTypes =
+                (bundle.getIntegerArrayList(KEY_ALLOWED_TYPES) ?: listOf<Int>()).map {
+                    MediaType.values()[it]
+                }.toSet()
             val multipleSelectionAllowed = bundle.getBoolean(KEY_CAN_MULTISELECT)
             val queueResults = bundle.getBoolean(KEY_QUEUE_RESULTS)
             val searchMode = SearchMode.values()[bundle.getInt(KEY_SEARCH_MODE)]
@@ -97,14 +109,15 @@ data class MediaPickerSetup(
         fun fromIntent(intent: Intent): MediaPickerSetup {
             val dataSource = DataSource.values()[intent.getIntExtra(KEY_PRIMARY_DATA_SOURCE, -1)]
             val availableDataSources = (
-                intent.getIntegerArrayListExtra(KEY_AVAILABLE_DATA_SOURCES)
-                    ?: listOf<Int>()
-                ).map {
-                DataSource.values()[it]
-            }.toSet()
-            val allowedTypes = (intent.getIntegerArrayListExtra(KEY_ALLOWED_TYPES) ?: listOf<Int>()).map {
-                MediaType.values()[it]
-            }.toSet()
+                    intent.getIntegerArrayListExtra(KEY_AVAILABLE_DATA_SOURCES)
+                        ?: listOf<Int>()
+                    ).map {
+                    DataSource.values()[it]
+                }.toSet()
+            val allowedTypes =
+                (intent.getIntegerArrayListExtra(KEY_ALLOWED_TYPES) ?: listOf<Int>()).map {
+                    MediaType.values()[it]
+                }.toSet()
             val multipleSelectionAllowed = intent.getBooleanExtra(KEY_CAN_MULTISELECT, false)
             val queueResults = intent.getBooleanExtra(KEY_QUEUE_RESULTS, false)
             val searchMode = SearchMode.values()[intent.getIntExtra(KEY_SEARCH_MODE, 0)]
@@ -122,6 +135,10 @@ data class MediaPickerSetup(
     }
 
     interface Factory {
-        fun build(source: DataSource, isMultiSelectAllowed: Boolean = false): MediaPickerSetup
+        fun build(
+            source: DataSource,
+            mediaTypes: MediaTypes = MediaTypes.EVERYTHING,
+            isMultiSelectAllowed: Boolean = false
+        ): MediaPickerSetup
     }
 }

--- a/mediapicker/domain/src/main/java/org/wordpress/android/mediapicker/api/MimeTypeProvider.kt
+++ b/mediapicker/domain/src/main/java/org/wordpress/android/mediapicker/api/MimeTypeProvider.kt
@@ -4,6 +4,7 @@ interface MimeTypeProvider {
     val imageTypes: List<String>
     val videoTypes: List<String>
     val audioTypes: List<String>
+    val documentTypes: List<String>
 
     fun isApplicationTypeSupported(applicationType: String): Boolean
     fun isMimeTypeSupported(mimeType: String): Boolean

--- a/mediapicker/domain/src/main/java/org/wordpress/android/mediapicker/model/MediaPickerContext.kt
+++ b/mediapicker/domain/src/main/java/org/wordpress/android/mediapicker/model/MediaPickerContext.kt
@@ -25,6 +25,10 @@ enum class MediaPickerContext(
         R.string.pick_audio, "*/*"
     ),
     MEDIA_FILE(
+        Intent.ACTION_GET_CONTENT,
+        R.string.pick_audio, "*/*"
+    ),
+    FILE(
         Intent.ACTION_OPEN_DOCUMENT,
         R.string.pick_file, "*/*"
     );

--- a/mediapicker/domain/src/main/java/org/wordpress/android/mediapicker/model/MediaType.kt
+++ b/mediapicker/domain/src/main/java/org/wordpress/android/mediapicker/model/MediaType.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.mediapicker.model
 
 import org.wordpress.android.mediapicker.model.MediaType.AUDIO
+import org.wordpress.android.mediapicker.model.MediaType.DOCUMENT
 import org.wordpress.android.mediapicker.model.MediaType.IMAGE
 import org.wordpress.android.mediapicker.model.MediaType.VIDEO
 
@@ -11,6 +12,15 @@ enum class MediaType {
 enum class MediaTypes(val allowedTypes: Set<MediaType>) {
     IMAGES(setOf(IMAGE)),
     VIDEOS(setOf(VIDEO)),
+    AUDIOS(setOf(AUDIO)),
+    DOCUMENTS(setOf(DOCUMENT)),
     IMAGES_AND_VIDEOS(setOf(IMAGE, VIDEO)),
-    EVERYTHING(setOf(IMAGE, VIDEO, AUDIO))
+    MEDIA(setOf(IMAGE, VIDEO, AUDIO)),
+    EVERYTHING(setOf(IMAGE, VIDEO, AUDIO, DOCUMENT));
+
+    companion object {
+        fun fromAllowedTypes(allowedTypes: Set<MediaType>) = values().firstOrNull {
+            it.allowedTypes == allowedTypes
+        } ?: EVERYTHING
+    }
 }

--- a/mediapicker/domain/src/main/res/values/strings.xml
+++ b/mediapicker/domain/src/main/res/values/strings.xml
@@ -3,7 +3,8 @@
     <string name="pick_photo">Select photo</string>
     <string name="pick_video">Select video</string>
     <string name="pick_audio">Select audio</string>
-    <string name="pick_media">Add image or video</string>
+    <string name="pick_photo_or_video">Add image or video</string>
+    <string name="pick_media">Add media file</string>
     <string name="pick_file">Add file</string>
     <string name="no_network_title" tools:ignore="UnusedResources">No network available</string>
     <string name="no_network_message" tools:ignore="UnusedResources">There is no network available</string>

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/MediaPickerUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/MediaPickerUtils.kt
@@ -49,6 +49,9 @@ class MediaPickerUtils @Inject constructor(
         if (openSystemPicker.allowMultipleSelection) {
             intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
         }
+        if (openSystemPicker.pickerContext.intentAction == Intent.ACTION_OPEN_DOCUMENT) {
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
         return Intent.createChooser(intent, context.getString(chooserContext.title))
     }
 

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/model/MediaPickerUiItem.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/model/MediaPickerUiItem.kt
@@ -34,6 +34,7 @@ internal sealed class MediaPickerUiItem(
         val identifier: Identifier,
         val fileName: String,
         val fileExtension: String? = null,
+        val mimeType: String? = null,
         val isSelected: Boolean = false,
         val selectedOrder: Int? = null,
         val showOrderCounter: Boolean = false,

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/model/UiStateModels.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/model/UiStateModels.kt
@@ -92,12 +92,12 @@ internal class UiStateModels {
                 }
             }
 
-            fun fromMediaType(type: MediaType): PermissionsRequested {
+            fun fromMediaType(type: MediaType): PermissionsRequested? {
                 return when (type) {
                     IMAGE -> IMAGES
                     VIDEO -> VIDEOS
                     AUDIO -> MUSIC
-                    else -> throw UnsupportedOperationException("Unsupported media type: $type")
+                    else -> null
                 }
             }
         }

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/MediaPickerFragment.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/MediaPickerFragment.kt
@@ -56,7 +56,6 @@ import org.wordpress.android.mediapicker.model.UiStateModels.ActionModeUiModel
 import org.wordpress.android.mediapicker.model.UiStateModels.FabUiModel
 import org.wordpress.android.mediapicker.model.UiStateModels.PermissionsRequested
 import org.wordpress.android.mediapicker.model.UiStateModels.PermissionsRequested.READ_STORAGE
-import org.wordpress.android.mediapicker.model.UiStateModels.PermissionsRequested.WRITE_STORAGE
 import org.wordpress.android.mediapicker.model.UiStateModels.PhotoListUiModel
 import org.wordpress.android.mediapicker.model.UiStateModels.PhotoListUiModel.Data
 import org.wordpress.android.mediapicker.model.UiStateModels.PhotoListUiModel.Empty
@@ -531,7 +530,7 @@ internal class MediaPickerFragment : Fragment() {
             } else {
                 if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
                     checkMediaPermissions(
-                        mediaPickerSetup.allowedTypes.map {
+                        mediaPickerSetup.allowedTypes.mapNotNull {
                             PermissionsRequested.fromMediaType(it)
                         }
                     )

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/FileThumbnailViewHolder.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/ui/viewholder/FileThumbnailViewHolder.kt
@@ -32,13 +32,13 @@ internal class FileThumbnailViewHolder(parent: ViewGroup, private val mediaThumb
         mediaThumbnailViewUtils.setupFileImageView(
             container,
             imgThumbnail,
-            item.fileName,
+            item.mimeType,
             item.isSelected,
             item.longClickAction,
             item.toggleAction,
             animateSelection
         )
-        fileType.text = item.fileExtension
+        fileType.text = item.fileExtension.orEmpty()
         fileName.text = item.fileName
     }
 }

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/ImageUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/ImageUtils.kt
@@ -1,20 +1,19 @@
 package org.wordpress.android.mediapicker.util
 
+import android.graphics.drawable.Icon
 import android.widget.ImageView
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.core.content.ContextCompat
 import androidx.core.widget.ImageViewCompat
 import com.bumptech.glide.Glide
-import kotlinx.coroutines.CoroutineScope
 import org.wordpress.android.mediapicker.R
 
 fun ImageView.setImageResourceWithTint(
-    @DrawableRes drawableResId: Int,
+    icon: Icon,
     @ColorRes colorResId: Int
 ) {
-    setImageDrawable(ContextCompat.getDrawable(context, drawableResId))
+    setImageIcon(icon)
     ImageViewCompat.setImageTintList(
         this,
         AppCompatResources.getColorStateList(context, colorResId)

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaThumbnailViewUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaThumbnailViewUtils.kt
@@ -34,7 +34,7 @@ internal class MediaThumbnailViewUtils {
     fun setupFileImageView(
         container: View,
         imgThumbnail: ImageView,
-        fileName: String,
+        mimeType: String?,
         isSelected: Boolean,
         longClickAction: LongClickAction,
         toggleAction: ToggleAction,
@@ -43,8 +43,8 @@ internal class MediaThumbnailViewUtils {
         imgThumbnail.cancelRequestAndClearImageView()
 
         // not an image or video, so show file name and file type
-        val placeholderResId = MediaUtils.getPlaceholder(fileName)
-        imgThumbnail.setImageResourceWithTint(placeholderResId, MPApiR.color.neutral_30)
+        val placeholderIcon = MediaUtils.getPlaceholder(container.context, mimeType.orEmpty())
+        imgThumbnail.setImageResourceWithTint(placeholderIcon, MPApiR.color.neutral_30)
 
         container.setOnClickListener {
             toggleAction.toggle()

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaUtils.kt
@@ -1,34 +1,32 @@
 package org.wordpress.android.mediapicker.util
 
+import android.content.Context
 import android.content.Intent
+import android.graphics.drawable.Icon
 import android.net.Uri
+import android.os.Build
 import org.wordpress.android.mediapicker.R
-import org.wordpress.android.util.MediaUtils
 
 object MediaUtils {
-    fun getPlaceholder(url: String?): Int {
-        return when {
-            MediaUtils.isValidImage(url) -> {
-                R.drawable.ic_image_white_24dp
+    fun getPlaceholder(context: Context, mimeType: String): Icon {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            context.contentResolver.getTypeInfo(mimeType).icon
+        } else {
+            val res = when {
+                mimeType.startsWith("audio/") -> R.drawable.ic_audio_white_24dp
+                mimeType.startsWith("video/") -> R.drawable.ic_video_camera_white_24dp
+                mimeType.startsWith("image/") -> R.drawable.ic_image_white_24dp
+
+                mimeType.contains("spreadsheet") ||
+                        mimeType == "application/vnd.ms-excel" -> R.drawable.media_spreadsheet
+
+                mimeType.contains("presentation") ||
+                        mimeType == "application/vnd.ms-powerpoint" -> R.drawable.media_powerpoint
+
+                else -> R.drawable.ic_pages_white_24dp
             }
-            MediaUtils.isDocument(url) -> {
-                R.drawable.ic_pages_white_24dp
-            }
-            MediaUtils.isPowerpoint(url) -> {
-                R.drawable.media_powerpoint
-            }
-            MediaUtils.isSpreadsheet(url) -> {
-                R.drawable.media_spreadsheet
-            }
-            MediaUtils.isVideo(url) -> {
-                R.drawable.ic_video_camera_white_24dp
-            }
-            MediaUtils.isAudio(url) -> {
-                R.drawable.ic_audio_white_24dp
-            }
-            else -> {
-                R.drawable.ic_image_multiple_white_24dp
-            }
+
+            Icon.createWithResource(context, res)
         }
     }
 

--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/viewmodel/MediaPickerViewModel.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/viewmodel/MediaPickerViewModel.kt
@@ -257,6 +257,7 @@ internal class MediaPickerViewModel @Inject constructor(
                     AUDIO, DOCUMENT -> FileItem(
                         fileName = it.name ?: "",
                         fileExtension = fileExtension,
+                        mimeType = it.mimeType,
                         identifier = it.identifier,
                         isSelected = isSelected,
                         selectedOrder = selectedOrder,

--- a/sampleapp/src/main/java/org/wordpress/android/sampleapp/MediaPickerSetupFactory.kt
+++ b/sampleapp/src/main/java/org/wordpress/android/sampleapp/MediaPickerSetupFactory.kt
@@ -6,24 +6,24 @@ import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.CAMERA
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.DEVICE
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.GIF_LIBRARY
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.SYSTEM_PICKER
+import org.wordpress.android.mediapicker.model.MediaTypes
 import org.wordpress.android.mediapicker.model.MediaTypes.EVERYTHING
-import org.wordpress.android.mediapicker.model.MediaTypes.IMAGES
 import org.wordpress.android.mediapicker.source.device.DeviceMediaPickerSetup
 import org.wordpress.android.mediapicker.source.gif.GifMediaPickerSetup
 import java.security.InvalidParameterException
 import javax.inject.Inject
 
 class MediaPickerSetupFactory @Inject constructor() : MediaPickerSetup.Factory {
-    override fun build(source: DataSource, isMultiSelectAllowed: Boolean): MediaPickerSetup {
+    override fun build(source: DataSource, mediaTypes: MediaTypes, isMultiSelectAllowed: Boolean): MediaPickerSetup {
         return when (source) {
             GIF_LIBRARY -> GifMediaPickerSetup.build(canMultiSelect = true)
             CAMERA -> DeviceMediaPickerSetup.buildCameraPicker()
             DEVICE -> DeviceMediaPickerSetup.buildMediaPicker(
-                mediaTypes = EVERYTHING,
+                mediaTypes = mediaTypes,
                 canMultiSelect = true
             )
             SYSTEM_PICKER -> DeviceMediaPickerSetup.buildSystemPicker(
-                mediaTypes = IMAGES,
+                mediaTypes = mediaTypes,
                 canMultiSelect = false
             )
             else -> throw InvalidParameterException("${source.name} source is not supported")

--- a/sampleapp/src/main/java/org/wordpress/android/sampleapp/SampleMimeTypeProvider.kt
+++ b/sampleapp/src/main/java/org/wordpress/android/sampleapp/SampleMimeTypeProvider.kt
@@ -4,9 +4,10 @@ import org.wordpress.android.mediapicker.api.MimeTypeProvider
 import javax.inject.Inject
 
 class SampleMimeTypeProvider @Inject constructor() : MimeTypeProvider {
-    override val imageTypes: List<String> = listOf("JPEG", "PNG")
+    override val imageTypes: List<String> = listOf("image/jpeg", "image/png")
     override val videoTypes: List<String> = emptyList()
     override val audioTypes: List<String> = emptyList()
+    override val documentTypes: List<String> = listOf("application/pdf")
 
     override fun isApplicationTypeSupported(applicationType: String): Boolean = true
     override fun isMimeTypeSupported(mimeType: String): Boolean = true


### PR DESCRIPTION
This PR is a preparation to be able to implement https://github.com/woocommerce/woocommerce-android/issues/6017

Please don't merge, I'll handle merging myself to synchronize between the different PRs.

It adds the following changes, each in a separate commit, reviewing them separately might be easier to follow:
1. Some changes to allow specifying `documents` as media types [5ec5523](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/pull/71/commits/5ec55236af68af31d5d7509f1c89d6776d046bd3)
2. A refractor to allow specifying different media types for different locations in the app 3595cc0
Before, we were hardcoding the media types in the Factory, which made it impossible to support different types for different features.
3.  Fixes to file thumbnails logic c219519, it was broken before this, and showed a default picture for all images.

| Before | After |
| --- | --- |
| <img width=240 src="https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/assets/1657201/009eaa7b-6d46-4927-a7e2-968025f484a8"/> |<img width=240 src="https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/assets/1657201/3f4d0745-958f-4e14-85dd-a8b11cd5ba35"/> |

4. Pass the correct permission flags when using Intent.ACTION_OPEN_DOCUMENT a4c8964
5. Remove non-useful code 3936647, this code was misleading, as it made it look like the internal media picker would list document files, but instead it was broken (`context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)` is an **app-specific** directory), and recent APIs [don't support](https://developer.android.com/training/data-storage/) this feature anymore, so there is no point in trying to fix it.
6. Crash fix when using the `DOCUMENT` media type 1d53378

### Testing
1. Open the sample app
2. Click on Local Device picker
3. Grant permissions if needed.
4. Confirm this lists the device's pictures.
5. Click on the photo icon in the top-right corner
6. Confirm the system picker lists pictures and PDF files.

More testing will be as part of the WCAndroid PRs.
