### PR TITLE
[Nullability Annotations to Java Classes] Add `wordpress.lint` Dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,9 @@ ext {
     kotlinxCoroutinesVersion = '1.5.2'
     squareupRetrofitVersion = "2.9.0"
 
+    // other
+    wordpressLintVersion = "2.0.0"
+
     // project
     mediaPickerDomainDependency = project.hasProperty("mediaPickerDomainVersion") ? "org.wordpress.mediapicker:domain:${project.getProperty("mediaPickerDomainVersion")}" : project(":mediapicker:domain")
 }

--- a/mediapicker/build.gradle
+++ b/mediapicker/build.gradle
@@ -58,6 +58,8 @@ android {
         implementation "com.github.chrisbanes:PhotoView:$chrisbanesPhotoviewVersion"
 
         implementation "org.wordpress:utils:$wordpressUtilsVersion"
+
+        lintChecks "org.wordpress:lint:$wordpressLintVersion"
     }
 }
 


### PR DESCRIPTION
This PR adds `wordPress-lint` checks to the project ([2.0.0](https://github.com/wordpress-mobile/WordPress-Lint-Android/releases/tag/2.0.0)).

FYI: Since the `mediapicker` module is still using Java files in it, it makes sense to utilize the `org.wordpress:lint` library on it. All other modules are all Kotlin, with no Java files in it. As such, there is no point in utilizing the `org.wordpress:lint` library on any other module.

-----

## To test:

1. Verifying that all the CI checks are successful (focus on the Lint related [check](https://buildkite.com/automattic/wordpress-mediapicker-android/builds/231#018b61fd-d4e1-4935-8d9a-33db3e85174d) and its [report](https://buildkiteartifacts.com/b26f1746-2f0c-49cc-bbd1-a45a5e24c351/a996dd63-4bf0-4d51-a63f-638847834b80/018b61fd-be52-4c79-85d5-b32b8c5065ac/018b61fd-d4e1-4935-8d9a-33db3e85174d/mediapicker/build/reports/lint-results-release.html?response-content-type=text%2Fhtml&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQPCP3C7LUXMJY5YE%2F20231024%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231024T141909Z&X-Amz-Expires=600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEBkaCXVzLWVhc3QtMSJGMEQCIC9QNy%2BO7t1CUjWeeFBxTq7yXnYDUR8mDC43ErFtbVwuAiA%2BM7svc9tsHHRrg3TzhY6Q7NAxVfvUM9Fhq3Wl16AVhirxAwhCEAAaDDAzMjM3OTcwNTMwMyIM2f9qdFn34RnWcNZuKs4DSyADkSU2kZ8TT1e%2Fo7HSBUMAflHu5Nzfa9KmIAgVnig4sYwHAPwLer7luWWptiTsp9d1MNWn3VBsH7ibI10EZa1t8pbfdKeKf%2Fj4l%2BL3wjp9o23mUO15Td8wNHF6wy9jtUztbm9mwQPY9cAfFpbTma20Fc9pOa6osdgpBWzo%2Fw47SBMDrW0qMNjH%2FHa1OkvmhuDP%2BNEfSndoHdmXHQq5Gj5QEJsUR5AKNwW5zAhrEds%2BywKjQIDUGoCyM%2Bh8fLErBMAfnou0N5FXqWl4RVyriVCRHJBhYDVDzl1fQy1HupUu5urMBwmXKXeEfCiB009sIldcHTTXqfrAcawfgoCItEBeZdViI%2FZgtTH%2FgtiVFADtp9IMXXwWf7OdvmE907cqlqDaBHt7B9W0bl04G8kGt3GjKauI%2FzGgPJzeQawoV5kGhTbrr6nAO8O%2FlsFW32SH03OEd4SPdWebUzKCIP9oHcMUxR8iH13EGoFyUBtmNApzsq53ZJ8creOjQ3PTjsILLQ%2FqPh8OvW6dBJo1k832TICjjoAoF%2FJCnLnSgyZRkpwxsCBKlu1xOn4CIccbkOW7DeNu7ieooTaAx5hxq%2Foe5xwMSwmSmJfM%2FyYG5wHOMPuM3qkGOqYBBZkhBodB6FaW13oW1RuWvBZATJWI3aZg8EwBo4mbywjSowqZNBCEcmbW2VTTXK8ZxQ3vEvujYu7Y3HN1AwNSWci7VqUJO4H4LDy54pGyTP5%2Fi2Dutw9g0kZe6gTotPtQZwAMvwFqF1PSL%2Ft0p6hrdjuSdXA%2Fl9CLyyg0EdzEjYcMRXJSnKcBAdRanCS6h1tmN9jlYylga2NuHX33DcmOKnTbyQfjlQ%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=3d4090d22d9262f2051c257aa9d08766c49412911cd247238112e6e3e976af4b)).
2. Verify that the new `MissingNullAnnotationOn*` correctness related rules are reporting as expected. For a reference, see screenshot below:

`mediapicker` module:

![image](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/assets/9729923/8837b93a-135c-4d0c-99d1-363a624889c4)
