### PR TITLE
[Build] Update Kotlin to 1.9.22

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 pluginManagement {
-    gradle.ext.kotlinVersion = '1.8.21'
+    gradle.ext.kotlinVersion = '1.9.22'
     gradle.ext.daggerVersion = '2.45'
     gradle.ext.agpVersion = '8.1.0'
     gradle.ext.detektVersion = '1.19.0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     gradle.ext.kotlinVersion = '1.9.22'
-    gradle.ext.daggerVersion = '2.45'
+    gradle.ext.daggerVersion = '2.46.1'
     gradle.ext.agpVersion = '8.1.0'
     gradle.ext.detektVersion = '1.19.0'
     gradle.ext.automatticPublishToS3Version = '0.8.0'


### PR DESCRIPTION
Required By: `Dependency Analysis PR`

This PR updates Kotlin to [1.9.22](https://github.com/JetBrains/kotlin/releases/tag/v1.9.22).

### Description

This update isn't that necessary, but should be considered anyway as it will do the following:
- Align this library, to that Kotlin version, which is already used by most of this library's clients and libraries.
- Unblock the usage of the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin for this project.
- Prepares this project for the Kotlin 2+ major update.

### Test

- Smoke test the `sampleapp` example app.
- Verifying that all the CI checks are successful.
- However, if you want to be thorough about reviewing this change, you could:
    - Quickly smoke test the [WCAndroid](https://github.com/woocommerce/woocommerce-android) app, with this version of `Media Picker`, or via composite builds, and see if it works as expected.
    - Test for build time increases (local & CI).