### PR TITLE
[Dependency Update] Update `a8c-ci-toolkit` to 3.4.2

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.15.0
+    - automattic/a8c-ci-toolkit#3.4.2
 
 agents:
   queue: "android"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,11 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.4.2
-
 agents:
   queue: "android"
 
@@ -13,7 +8,7 @@ steps:
   - label: "Gradle Wrapper Validation"
     command: |
       validate_gradle_wrapper
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
@@ -22,12 +17,12 @@ steps:
     key: "detekt"
     command: |
       ./gradlew detekt
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "**/build/reports/detekt/detekt.html"
   - label: "lint"
     key: "lint"
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     command: |
       ./gradlew lintRelease
     artifact_paths:
@@ -39,36 +34,36 @@ steps:
     depends_on:
       - "detekt"
       - "lint"
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/publish-mediapicker-domain.sh
   - label: "Publish :mediapicker:source-device"
     depends_on:
       - "publish-mediapicker-domain"
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/publish-mediapicker-source-device.sh
   - label: "Publish :mediapicker:source-camera"
     depends_on:
       - "publish-mediapicker-domain"
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/publish-mediapicker-source-camera.sh
   - label: "Publish :mediapicker:source-gif"
     depends_on:
       - "publish-mediapicker-domain"
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/publish-mediapicker-source-gif.sh
   - label: "Publish :mediapicker:source-wordpress"
     depends_on:
       - "publish-mediapicker-domain"
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/publish-mediapicker-source-wordpress.sh
   - label: "Publish :mediapicker"
     depends_on:
       - "publish-mediapicker-domain"
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/publish-mediapicker.sh

--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -4,7 +4,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.15.0
+    - automattic/a8c-ci-toolkit#3.4.2
 
 agents:
   queue: "android"

--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -1,11 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.4.2
-
 agents:
   queue: "android"
 
@@ -14,7 +9,7 @@ steps:
     command: |
       echo "--- 📊 Analyzing"
       ./gradlew buildHealth
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "build/reports/dependency-analysis/build-health-report.*"
     notify:

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+ # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
+ # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
+
+ export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.4.2"


### PR DESCRIPTION
### Description

This PR updates `a8c-ci-toolkit` to [3.4.2](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/tag/3.4.2).

FYI: The breaking change in `3.0.0` is due to removing the `nvm_install` command, but this repo doesn't use that anywhere anyway. As such, it is safe to apply this update.

### Testing Instructions

- Make sure CI is green (🟢).