### PR TITLE
Remove not-needed permissions for the Camera function

### DIFF
--- a/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaPickerPermissionUtils.kt
+++ b/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaPickerPermissionUtils.kt
@@ -55,25 +55,15 @@ internal class MediaPickerPermissionUtils @Inject constructor(
     }
 
     fun hasPermissionsToTakePhotos(): Boolean {
-        return hasCameraPermission() && (VERSION.SDK_INT > VERSION_CODES.P || hasWriteStoragePermission())
+        return hasCameraPermission()
     }
 
     val permissionsForTakingPhotos: List<PermissionsRequested>
-        get() = if (VERSION.SDK_INT > VERSION_CODES.P) {
-            listOf(CAMERA)
-        } else {
-            listOf(CAMERA, WRITE_STORAGE)
-        }
+        get() = listOf(CAMERA)
 
     fun hasReadStoragePermission(): Boolean {
         return ContextCompat.checkSelfPermission(
             context, permission.READ_EXTERNAL_STORAGE
-        ) == PackageManager.PERMISSION_GRANTED
-    }
-
-    private fun hasWriteStoragePermission(): Boolean {
-        return ContextCompat.checkSelfPermission(
-            context, permission.WRITE_EXTERNAL_STORAGE
         ) == PackageManager.PERMISSION_GRANTED
     }
 


### PR DESCRIPTION
Closes: #81 

The pictures are saved to our own folder, so we don't need any permissions to read them, and the Camera app is granted permissions to write to them via the FileProvider.

### Testing

For testing, please check the WCAndroid PR https://github.com/woocommerce/woocommerce-android/pull/12127