### PR TITLE
[Dependency Analysis] Remove Unused Dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ ext {
     wordpressUtilsVersion = "2.6.0"
 
     // main
+    androidxAnnotationVersion = '1.6.0'
     androidxAppcompatVersion = '1.4.2'
     androidxCoreVersion = '1.12.0'
     androidxDatastoreVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ ext {
     androidxDatastoreVersion = '1.0.0'
     androidxConstraintlayoutVersion = '2.1.4'
     androidxLifecycleVersion = '2.6.2'
-    androidxNavigationVersion = '2.5.3'
+    androidxFragmentVersion = '1.5.4'
     androidxSwipeToRefreshVersion = '1.1.0'
     chrisbanesPhotoviewVersion = '2.3.0'
     glideVersion = '4.13.2'

--- a/mediapicker/build.gradle
+++ b/mediapicker/build.gradle
@@ -38,7 +38,7 @@ android {
 
         implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinxCoroutinesVersion"
 
-        implementation "androidx.navigation:navigation-fragment-ktx:$androidxNavigationVersion"
+        implementation "androidx.fragment:fragment-ktx:$androidxFragmentVersion"
         implementation "androidx.core:core-ktx:$androidxCoreVersion"
         implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
         implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintlayoutVersion"

--- a/mediapicker/domain/build.gradle
+++ b/mediapicker/domain/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
     id 'org.jetbrains.kotlin.plugin.parcelize'
-    id 'org.jetbrains.kotlin.kapt'
     id 'maven-publish'
     id "com.automattic.android.publish-to-s3"
 }

--- a/mediapicker/domain/build.gradle
+++ b/mediapicker/domain/build.gradle
@@ -28,7 +28,7 @@ android {
 }
 
 dependencies {
-    implementation "androidx.core:core-ktx:$androidxCoreVersion"
+    implementation "androidx.annotation:annotation:$androidxAnnotationVersion"
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinxCoroutinesVersion"
 }

--- a/mediapicker/source-camera/build.gradle
+++ b/mediapicker/source-camera/build.gradle
@@ -31,6 +31,15 @@ dependencies {
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
 }
 
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // This dependency is actually needed because of 'androidx.core.content.FileProvider' on 'AndroidManifest.xml'.
+            exclude("androidx.core:core-ktx")
+        }
+    }
+}
+
 project.afterEvaluate {
     publishing {
         publications {

--- a/mediapicker/source-device/build.gradle
+++ b/mediapicker/source-device/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 
     implementation "com.google.dagger:hilt-android:$gradle.ext.daggerVersion"
     implementation "com.google.dagger:hilt-android-compiler:$gradle.ext.daggerVersion"
-    kapt "com.google.dagger:hilt-compiler:$gradle.ext.daggerVersion"
+    kapt "com.google.dagger:dagger-compiler:$gradle.ext.daggerVersion"
 }
 
 project.afterEvaluate {

--- a/mediapicker/source-gif/build.gradle
+++ b/mediapicker/source-gif/build.gradle
@@ -42,6 +42,15 @@ dependencies {
     implementation "org.wordpress:utils:$wordpressUtilsVersion"
 }
 
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // This dependency is actually needed otherwise 'tenor' fails with 'NoClassDefFoundError' on 'GsonConverterFactory'.
+            exclude("com.squareup.retrofit2:converter-gson")
+        }
+    }
+}
+
 project.afterEvaluate {
     publishing {
         publications {

--- a/mediapicker/source-wordpress/build.gradle
+++ b/mediapicker/source-wordpress/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 
     implementation "com.google.dagger:hilt-android:$gradle.ext.daggerVersion"
     implementation "com.google.dagger:hilt-android-compiler:$gradle.ext.daggerVersion"
-    kapt "com.google.dagger:hilt-compiler:$gradle.ext.daggerVersion"
+    kapt "com.google.dagger:dagger-compiler:$gradle.ext.daggerVersion"
 
     implementation "org.wordpress:utils:$wordpressUtilsVersion"
 

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -67,3 +67,12 @@ dependencies {
     implementation "com.google.dagger:hilt-android:$gradle.ext.daggerVersion"
     kapt "com.google.dagger:hilt-compiler:$gradle.ext.daggerVersion"
 }
+
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // This dependency is not needed but it is kept to preserve the module's default configuration.
+            exclude(":mediapicker:source-wordpress")
+        }
+    }
+}

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -61,7 +61,6 @@ dependencies {
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinxCoroutinesVersion"
 
-    implementation "androidx.core:core-ktx:$androidxCoreVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
     implementation "com.google.android.material:material:$googleMaterialVersion"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
     gradle.ext.agpVersion = '8.1.0'
     gradle.ext.detektVersion = '1.19.0'
     gradle.ext.automatticPublishToS3Version = '0.8.0'
-    gradle.ext.dependencyAnalysisVersion = '1.28.0'
+    gradle.ext.dependencyAnalysisVersion = '1.33.0'
 
     plugins {
         id 'io.gitlab.arturbosch.detekt' version gradle.ext.detektVersion


### PR DESCRIPTION
Project Thread: paaHJt-6YV-p2

### Description

Based on the `unused` related advises generated by the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin, this PR removes all unused dependencies from this project.

FYI: As part of this change, the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin got also updated to its latest [1.33.0](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CHANGELOG.md#version-1330) version.

### Testing Steps

1. Tooling:
    - Run the `./gradlew buildHealth` task and verify that there is no `unused` related advise remaining within both reports, JSON and txt included:
        - `build-health-report.json` -> Search for `unusedCount`
        - `build-health-report.txt` -> Search for `unused`
    - Check the manually triggered [scheduled build](https://buildkite.com/automattic/wordpress-mediapicker-android/builds/278) and verify that everything works as expected with this newer version of the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin ([1.33.0](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CHANGELOG.md#version-1330)).
3. Testing:
    - Smoke test the `Sample` app, try out all available screens and functionality. Verify everything is working as expected.
    - Also, if you want to be thorough about reviewing the changes, you could quickly smoke test the [WCAndroid](https://github.com/woocommerce/woocommerce-android) with this version of `MediaPicker`, or via composite builds, and see if it works as expected.