### PR TITLE
Updates Dagger version to latest one. 

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     gradle.ext.kotlinVersion = '1.9.24'
-    gradle.ext.daggerVersion = '2.46.1'
+    gradle.ext.daggerVersion = '2.55'
     gradle.ext.agpVersion = '8.1.0'
     gradle.ext.detektVersion = '1.19.0'
     gradle.ext.automatticPublishToS3Version = '0.8.0'


### PR DESCRIPTION
This PR updates the Dagger version to `2.55`.

This update is needed to be able to upgrade Dagger version in client app of Media Picker. We found out that if Dagger is updated in the client app to a version above `2.51`, but Media picker library doesn't update Dagger, then MediaPickerViewModel will crash when attempting to instantiate it. More context [here](https://github.com/woocommerce/woocommerce-android/pull/13305). 

There's not much to be tested here. Only that all the checks pass. Going over the test instructions from [this PR](https://github.com/woocommerce/woocommerce-android/pull/13402) should be enough to ensure nothing is broken. 