### PR TITLE
[Deps] Update Dependency Analysis Plugin to `2.19.0` and Fix CI Notifications

### DIFF
--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -12,6 +12,15 @@ steps:
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "build/reports/dependency-analysis/build-health-report.*"
-    notify:
-      - slack: "#android-core-notifs"
-        if: build.state == "failed"
+
+notify:
+  - slack:
+      channels:
+        - "#android-core-notifs"
+      message: "Dependency analysis succeeded."
+    if: build.state == "passed"
+  - slack:
+      channels:
+        - "#android-core-notifs"
+      message: "Dependency analysis failed."
+    if: build.state == "failed"

--- a/mediapicker/build.gradle
+++ b/mediapicker/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'dagger.hilt.android.plugin'
     id 'maven-publish'
     id "com.automattic.android.publish-to-s3"
+    id "com.autonomousapps.dependency-analysis"
 }
 
 android {

--- a/mediapicker/domain/build.gradle
+++ b/mediapicker/domain/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.parcelize'
     id 'maven-publish'
     id "com.automattic.android.publish-to-s3"
+    id "com.autonomousapps.dependency-analysis"
 }
 
 android {

--- a/mediapicker/source-camera/build.gradle
+++ b/mediapicker/source-camera/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'maven-publish'
     id "com.automattic.android.publish-to-s3"
+    id "com.autonomousapps.dependency-analysis"
 }
 
 android {

--- a/mediapicker/source-device/build.gradle
+++ b/mediapicker/source-device/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'dagger.hilt.android.plugin'
     id 'maven-publish'
     id "com.automattic.android.publish-to-s3"
+    id "com.autonomousapps.dependency-analysis"
 }
 
 android {

--- a/mediapicker/source-gif/build.gradle
+++ b/mediapicker/source-gif/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'dagger.hilt.android.plugin'
     id 'maven-publish'
     id "com.automattic.android.publish-to-s3"
+    id "com.autonomousapps.dependency-analysis"
 }
 
 android {

--- a/mediapicker/source-wordpress/build.gradle
+++ b/mediapicker/source-wordpress/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'dagger.hilt.android.plugin'
     id 'maven-publish'
     id "com.automattic.android.publish-to-s3"
+    id "com.autonomousapps.dependency-analysis"
 }
 
 android {

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'org.jetbrains.kotlin.kapt'
     id 'dagger.hilt.android.plugin'
+    id "com.autonomousapps.dependency-analysis"
 }
 
 repositories {

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
     gradle.ext.agpVersion = '8.4.0'
     gradle.ext.detektVersion = '1.19.0'
     gradle.ext.automatticPublishToS3Version = '0.8.0'
-    gradle.ext.dependencyAnalysisVersion = '1.33.0'
+    gradle.ext.dependencyAnalysisVersion = '2.19.0'
 
     plugins {
         id 'io.gitlab.arturbosch.detekt' version gradle.ext.detektVersion


### PR DESCRIPTION
Closes: [AINFRA-2127](https://linear.app/a8c/issue/AINFRA-2127)                                                                                                          
Closes: [AINFRA-2122](https://linear.app/a8c/issue/AINFRA-2122)                                                                                                          
                                                                                                                                                                           
---                                                                                                                                                                      

### Description

PR #89 (adc599a) updated Kotlin to [2.1.20](https://github.com/JetBrains/kotlin/releases/tag/v2.1.20), which produces Kotlin metadata version [2.2.0](https://github.com/JetBrains/kotlin/releases/tag/v2.2.0). The dependency analysis plugin [1.33.0](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CHANGELOG.md#version-1330) bundles `kotlinx-metadata-jvm` that only supports metadata up to [2.1.0](https://github.com/JetBrains/kotlin/releases/tag/v2.1.0), causing `buildHealth` to fail with:

> Provided Metadata instance has version 2.2.0, while maximum supported version is 2.1.0.

This PR updates the dependency analysis plugin from [1.33.0](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CHANGELOG.md#version-1330) to [2.19.0](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CHANGELOG.md#version-2190), which bumps `kotlinx-metadata-jvm` to [2.1.21](https://github.com/JetBrains/kotlin/releases/tag/v2.1.21) adding support for K2.2 projects. Version [2.19.0](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CHANGELOG.md#version-2190) is the latest available within the 2.x line — version [3.x](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CHANGELOG.md#version-300) requires Gradle [8.11](https://docs.gradle.org/8.11/release-notes.html) minimum, while the project currently uses Gradle [8.6](https://docs.gradle.org/8.6/release-notes.html).

Additionally, v2.x no longer auto-applies the plugin to subprojects, so each module now explicitly applies `com.autonomousapps.dependency-analysis` in its plugins block.

Finally, the Slack notify configuration in the dependency analysis pipeline is moved from step level to pipeline level with both passed and failed notifications, as step-level notify only supports a subset of conditions.

---

### Testing Steps

1. Tooling:
    - Run the `./gradlew buildHealth` task and verify that it passes successfully
    - Check the generated reports and verify they contain analysis for all modules:
        - `build/reports/dependency-analysis/build-health-report.txt`
        - `build/reports/dependency-analysis/build-health-report.json`
    - Trigger a manual [scheduled build](https://buildkite.com/automattic/wordpress-mediapicker-android) and verify that the pipeline passes and Slack notifications are sent to `#android-core-notifs`
        - Failure: Build: [384](https://buildkite.com/automattic/wordpress-mediapicker-android/builds/384) + Slack Notification: p1772461510332639-slack-C0787KRDYDC)
        - Success: Build: [386](https://buildkite.com/automattic/wordpress-mediapicker-android/builds/386) + Slack Notification: p1772463926416329-slack-C0787KRDYDC
2. Testing:
    - Smoke test the `Sample` app, try out all available screens and functionality. Verify everything is working as expected.